### PR TITLE
Fixed wrong ObjectSide coordinate values

### DIFF
--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -10,9 +10,9 @@ interface Object : ManimInstr {
 
 enum class ObjectSide(var coord: Pair<Double, Double>) {
     ABOVE(Pair(0.0, 0.25)),
-    BELOW(Pair(-0.25, 0.0)),
+    BELOW(Pair(0.0, -0.25)),
     LEFT(Pair(-0.25, 0.0)),
-    RIGHT(Pair(0.025, 0.0));
+    RIGHT(Pair(0.25, 0.0));
 
     fun addOffset(offset: Int): ObjectSide {
         val newCoord = if (this == ABOVE) {


### PR DESCRIPTION
### Clubhouse Ticket
[ch{105}]({https://app.clubhouse.io/manim-dsl/story/105/investigate-object-side-values})

### Description

Fixes wrong coordinate values for ObjectSide enum to reflect correct position when moving object relative to another object.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue) :bug

### How Has This Been Tested?

Tested locally for correct movement.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules