### PR TITLE
Extend IR to take customisable inputs for aesthetics

### DIFF
--- a/src/main/kotlin/com/manimdsl/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/ASTExecutor.kt
@@ -114,7 +114,7 @@ class ASTExecutor(
                 val numStack = variables.values.filterIsInstance(StackValue::class.java).lastOrNull()
                 val (instructions, newObject) = if (numStack == null) {
                     val stackInit = InitStructure(
-                        Coordinate(2, -1),
+                        Coord(2.0, -1.0),
                         Alignment.HORIZONTAL,
                         variableNameGenerator.generateNameFromPrefix("empty"),
                         identifier

--- a/src/main/kotlin/com/manimdsl/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/ASTExecutor.kt
@@ -114,8 +114,7 @@ class ASTExecutor(
                 val numStack = variables.values.filterIsInstance(StackValue::class.java).lastOrNull()
                 val (instructions, newObject) = if (numStack == null) {
                     val stackInit = InitStructure(
-                        2,
-                        -1,
+                        Coordinate(2, -1),
                         Alignment.HORIZONTAL,
                         variableNameGenerator.generateNameFromPrefix("empty"),
                         identifier
@@ -123,7 +122,8 @@ class ASTExecutor(
                     // Add to stack of objects to keep track of identifier
                     Pair(listOf(stackInit), stackInit)
                 } else {
-                    val stackInit = InitStructureRelative(
+                    val stackInit = InitStructure(
+                        RelativeToMoveIdent,
                         Alignment.HORIZONTAL,
                         variableNameGenerator.generateNameFromPrefix("empty"),
                         identifier,

--- a/src/main/kotlin/com/manimdsl/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/ASTExecutor.kt
@@ -61,21 +61,21 @@ class ASTExecutor(
                 return when (node.dataStructureMethod) {
                     is StackType.PushMethod -> {
                         val doubleValue = executeExpression(node.arguments[0], true) as DoubleValue
-                        val secondObject = if (ds.stack.empty()) ds.initObject else ds.stack.peek().second
+                        val topOfStack = if (ds.stack.empty()) ds.initObject else ds.stack.peek().second
 
-                        val hasOldShape = doubleValue.manimObject != null
-
-                        val rectangleShape = Rectangle(doubleValue.value.toString())
-                        val oldShape = doubleValue.manimObject ?: EmptyMObject
-                        val rectangle = if (hasOldShape) oldShape else NewMObject(
-                            rectangleShape,
-                            variableNameGenerator.generateShapeName(rectangleShape),
+                        val hasOldMObject = doubleValue.manimObject != null
+                        val oldMObject = doubleValue.manimObject ?: EmptyMObject
+                        val rectangle = if (hasOldMObject) oldMObject else NewMObject(
+                            Rectangle(
+                                variableNameGenerator.generateNameFromPrefix("rectangle"),
+                                doubleValue.value.toString()
+                            ),
                             codeTextVariable
                         )
 
                         val instructions =
-                            mutableListOf<ManimInstr>(MoveObject(rectangle.ident, secondObject.ident, ObjectSide.ABOVE))
-                        if (!hasOldShape) {
+                            mutableListOf<ManimInstr>(MoveObject(rectangle.shape, topOfStack.shape, ObjectSide.ABOVE))
+                        if (!hasOldMObject) {
                             instructions.add(0, rectangle)
                         }
 
@@ -85,13 +85,13 @@ class ASTExecutor(
                     }
                     is StackType.PopMethod -> {
                         val poppedValue = ds.stack.pop()
-                        val secondObject = if (ds.stack.empty()) ds.initObject else ds.stack.peek().second
+                        val newTopOfStack = if (ds.stack.empty()) ds.initObject else ds.stack.peek().second
 
                         val topOfStack = poppedValue.second
                         val instructions = listOf(
                             MoveObject(
-                                topOfStack.ident,
-                                secondObject.ident,
+                                topOfStack.shape,
+                                newTopOfStack.shape,
                                 ObjectSide.ABOVE,
                                 20,
                                 !insideMethodCall
@@ -127,7 +127,7 @@ class ASTExecutor(
                         Alignment.HORIZONTAL,
                         variableNameGenerator.generateNameFromPrefix("empty"),
                         identifier,
-                        numStack.initObject.ident
+                        numStack.initObject.shape
                     )
                     Pair(listOf(stackInit), stackInit)
                 }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -1,6 +1,7 @@
 package com.manimdsl.linearrepresentation
 
 import com.manimdsl.ExecValue
+import com.manimdsl.shapes.Shape
 
 interface ManimInstr {
     fun toPython(): List<String>
@@ -25,8 +26,8 @@ data class MoveToLine(val lineNumber: Int, val pointerName: String, val codeBloc
 }
 
 data class MoveObject(
-    val ident: String,
-    val moveToIdent: String,
+    val shape: Shape,
+    val moveToShape: Shape,
     val objectSide: ObjectSide,
     val offset: Int = 0,
     val fadeOut: Boolean = false
@@ -34,9 +35,9 @@ data class MoveObject(
     ManimInstr {
     override fun toPython(): List<String> {
         val instructions =
-            mutableListOf("self.move_relative_to_obj($ident, $moveToIdent, ${objectSide.addOffset(offset)})")
+            mutableListOf("self.move_relative_to_obj($shape, $moveToShape, ${objectSide.addOffset(offset)})")
         if (fadeOut) {
-            instructions.add("self.play(FadeOut($ident))")
+            instructions.add("self.play(FadeOut($shape))")
         }
         return instructions
     }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -1,5 +1,6 @@
 package com.manimdsl.linearrepresentation
 
+import com.manimdsl.shapes.CodeBlockShape
 import com.manimdsl.shapes.Shape
 
 /** Objects **/
@@ -8,7 +9,11 @@ interface MObject : ManimInstr {
     val ident: String
 }
 
-data class Coord(val x: Double, val y: Double) {
+/** Positioning **/
+interface Position
+object RelativeToMoveIdent : Position
+
+data class Coord(val x: Double, val y: Double) : Position {
     override fun toString(): String {
         return "$x, $y"
     }
@@ -50,10 +55,6 @@ data class CodeBlock(
     }
 }
 
-interface Position
-
-data class Coordinate(val x: Int, val y: Int) : Position
-object RelativeToMoveIdent : Position
 
 data class InitStructure(
     val position: Position, val alignment: Alignment, override val ident: String,
@@ -63,7 +64,7 @@ data class InitStructure(
         val python = mutableListOf("$ident = Init_structure(\"${text}\", ${alignment.angle}).build()")
         python.add(
             when (position) {
-                is Coordinate -> "$ident.to_edge(np.array([${position.x}, ${position.y}, 0]))"
+                is Coord -> "$ident.to_edge(np.array([${position.x}, ${position.y}, 0]))"
                 else -> "self.place_relative_to_obj($ident, $moveIdent, ${ObjectSide.LEFT.addOffset(0)})"
             }
         )

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -74,10 +74,8 @@ data class InitStructure(
 
 data class NewMObject(val shape: Shape, override val ident: String, val codeBlockVariable: String) : MObject {
     override fun toPython(): List<String> {
-        val style = shape.getStyle()
         return listOf(
-            "$ident = ${shape.className}(\"${shape.text}\"" +
-                    "${if (style.isNotEmpty()) ", ${style.joinToString(", ")}" else ""}).build()",
+            "$ident = ${shape.getConstructor()}",
             "self.place_relative_to_obj($ident, $codeBlockVariable, ${ObjectSide.RIGHT.addOffset(0)})",
             "self.play(FadeIn($ident))"
         )

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -1,6 +1,7 @@
 package com.manimdsl.linearrepresentation
 
 import com.manimdsl.shapes.CodeBlockShape
+import com.manimdsl.shapes.InitStructureShape
 import com.manimdsl.shapes.Shape
 
 /** Objects **/
@@ -48,7 +49,7 @@ data class CodeBlock(
 ) : MObject {
     override fun toPython(): List<String> {
         return listOf(
-            "$ident = ${CodeBlockShape(lines, textColor, textWeight, font).getConstructor()}",
+            "$ident = ${CodeBlockShape(lines, textColor, textWeight, font)}",
             "$codeTextName = $ident.build()",
             "self.place_at($codeTextName, -1, 0)",
             "self.play(FadeIn($codeTextName))",
@@ -59,11 +60,19 @@ data class CodeBlock(
 
 
 data class InitStructure(
-    val position: Position, val alignment: Alignment, override val ident: String,
-    val text: String, val moveIdent: String? = null
+    val position: Position,
+    val alignment: Alignment,
+    override val ident: String,
+    val text: String,
+    val moveIdent: String? = null,
+    val color: String? = null,
+    val textColor: String? = null,
+    val textWeight: String? = null,
+    val font: String? = null
 ) : MObject {
     override fun toPython(): List<String> {
-        val python = mutableListOf("$ident = Init_structure(\"${text}\", ${alignment.angle}).build()")
+        val python =
+            mutableListOf("$ident = ${InitStructureShape(text, alignment, color, textColor, textWeight, font)}")
         python.add(
             when (position) {
                 is Coord -> "$ident.to_edge(np.array([${position.x}, ${position.y}, 0]))"
@@ -78,7 +87,7 @@ data class InitStructure(
 data class NewMObject(val shape: Shape, override val ident: String, val codeBlockVariable: String) : MObject {
     override fun toPython(): List<String> {
         return listOf(
-            "$ident = ${shape.getConstructor()}",
+            "$ident = $shape",
             "self.place_relative_to_obj($ident, $codeBlockVariable, ${ObjectSide.RIGHT.addOffset(0)})",
             "self.play(FadeIn($ident))"
         )

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -41,12 +41,14 @@ data class CodeBlock(
     val lines: List<String>,
     override val ident: String,
     val codeTextName: String,
-    val pointerName: String
+    val pointerName: String,
+    val textColor: String? = null,
+    val textWeight: String? = null,
+    val font: String? = null
 ) : MObject {
-
     override fun toPython(): List<String> {
         return listOf(
-            "$ident = Code_block([\"${lines.joinToString("\",\"")}\"])",
+            "$ident = ${CodeBlockShape(lines, textColor, textWeight, font).getConstructor()}",
             "$codeTextName = $ident.build()",
             "self.place_at($codeTextName, -1, 0)",
             "self.play(FadeIn($codeTextName))",

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -79,7 +79,7 @@ data class InitStructureRelative(
 data class NewMObject(val shape: Shape, override val ident: String, val codeBlockVariable: String) : MObject {
     override fun toPython(): List<String> {
         return listOf(
-            "$ident = ${shape.className}(\"${shape.text}\").build()",
+            "$ident = ${shape.className}(\"${shape.text}\", ${shape.getStyle().joinToString(", ")}).build()",
             "self.place_relative_to_obj($ident, $codeBlockVariable, ${ObjectSide.RIGHT.addOffset(0)})",
             "self.play(FadeIn($ident))"
         )

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -34,29 +34,29 @@ sealed class ShapeWithText : Shape() {
 class Rectangle(
     override val ident: String,
     override val text: String,
-    private val color: String? = null,
-    private val textColor: String? = null,
-    private val textWeight: String? = null,
-    private val font: String? = null,
+    color: String? = null,
+    textColor: String? = null,
+    textWeight: String? = null,
+    font: String? = null,
 ) : ShapeWithText() {
     override val classPath: String = "python/rectangle.py"
     override val className: String = "Rectangle_block"
     override val pythonVariablePrefix: String = "rectangle"
 
     init {
-        color?.let { style.addStyleAttribute(Color(color)) }
-        textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
-        textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
-        font?.let { style.addStyleAttribute(Font(font)) }
+        color?.let { style.addStyleAttribute(Color(it)) }
+        textColor?.let { style.addStyleAttribute(TextColor(it)) }
+        textWeight?.let { style.addStyleAttribute(TextWeight(it)) }
+        font?.let { style.addStyleAttribute(Font(it)) }
     }
 }
 
 class CodeBlockShape(
     override val ident: String,
     lines: List<String>,
-    private val textColor: String? = null,
-    private val textWeight: String? = null,
-    private val font: String? = null
+    textColor: String? = null,
+    textWeight: String? = null,
+    font: String? = null
 ) : Shape() {
     override val classPath: String = "python/code_block.py"
     override val className: String = "Code_block"
@@ -64,9 +64,9 @@ class CodeBlockShape(
     override val text: String = "[\"${lines.joinToString("\",\"")}\"]"
 
     init {
-        textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
-        textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
-        font?.let { style.addStyleAttribute(Font(font)) }
+        textColor?.let { style.addStyleAttribute(TextColor(it)) }
+        textWeight?.let { style.addStyleAttribute(TextWeight(it)) }
+        font?.let { style.addStyleAttribute(Font(it)) }
     }
 
     override fun getConstructor(): String {
@@ -78,20 +78,20 @@ class InitStructureShape(
     override val ident: String,
     override val text: String,
     private val alignment: Alignment,
-    private val color: String? = null,
-    private val textColor: String? = null,
-    private val textWeight: String? = null,
-    private val font: String? = null
+    color: String? = null,
+    textColor: String? = null,
+    textWeight: String? = null,
+    font: String? = null
 ) : ShapeWithText() {
     override val classPath: String = "python/init_structure.py"
     override val className: String = "Init_structure"
     override val pythonVariablePrefix: String = ""
 
     init {
-        color?.let { style.addStyleAttribute(Color(color)) }
-        textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
-        textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
-        font?.let { style.addStyleAttribute(Font(font)) }
+        color?.let { style.addStyleAttribute(Color(it)) }
+        textColor?.let { style.addStyleAttribute(TextColor(it)) }
+        textWeight?.let { style.addStyleAttribute(TextWeight(it)) }
+        font?.let { style.addStyleAttribute(Font(it)) }
     }
 
     override fun getConstructor(): String {

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -3,24 +3,42 @@ package com.manimdsl.shapes
 import com.manimdsl.linearrepresentation.Alignment
 
 sealed class Shape {
+    abstract val ident: String
     abstract val text: String
     abstract val classPath: String
     abstract val className: String
     abstract val pythonVariablePrefix: String
     val style = Style()
 
+    open fun getConstructor(): String {
+        return "$ident = ${className}(\"${text}\"$style)"
+    }
+
     override fun toString(): String {
-        return "${className}(\"${text}\"$style).build()"
+        return "$ident.all"
+    }
+}
+
+sealed class ShapeWithText : Shape() {
+    // Python shape classes which has shape and text members to manipulate color
+
+    fun getTextMObject(): String {
+        return "$ident.text"
+    }
+
+    fun getShapeMObject(): String {
+        return "$ident.shape"
     }
 }
 
 class Rectangle(
+    override val ident: String,
     override val text: String,
     private val color: String? = null,
     private val textColor: String? = null,
     private val textWeight: String? = null,
-    private val font: String? = null
-) : Shape() {
+    private val font: String? = null,
+) : ShapeWithText() {
     override val classPath: String = "python/rectangle.py"
     override val className: String = "Rectangle_block"
     override val pythonVariablePrefix: String = "rectangle"
@@ -34,6 +52,7 @@ class Rectangle(
 }
 
 class CodeBlockShape(
+    override val ident: String,
     lines: List<String>,
     private val textColor: String? = null,
     private val textWeight: String? = null,
@@ -50,19 +69,20 @@ class CodeBlockShape(
         font?.let { style.addStyleAttribute(Font(font)) }
     }
 
-    override fun toString(): String {
-        return "${className}($text$style)"
+    override fun getConstructor(): String {
+        return "$ident = ${className}($text$style)"
     }
 }
 
 class InitStructureShape(
+    override val ident: String,
     override val text: String,
     private val alignment: Alignment,
     private val color: String? = null,
     private val textColor: String? = null,
     private val textWeight: String? = null,
     private val font: String? = null
-) : Shape() {
+) : ShapeWithText() {
     override val classPath: String = "python/init_structure.py"
     override val className: String = "Init_structure"
     override val pythonVariablePrefix: String = ""
@@ -74,7 +94,15 @@ class InitStructureShape(
         font?.let { style.addStyleAttribute(Font(font)) }
     }
 
-    override fun toString(): String {
-        return "${className}(\"$text\", ${alignment.angle}$style).build()"
+    override fun getConstructor(): String {
+        return "$ident = ${className}(\"$text\", ${alignment.angle}$style)"
     }
+}
+
+object NullShape : Shape() {
+    override val ident: String = ""
+    override val text: String = ""
+    override val classPath: String = ""
+    override val className: String = ""
+    override val pythonVariablePrefix: String = ""
 }

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -1,5 +1,7 @@
 package com.manimdsl.shapes
 
+import com.manimdsl.linearrepresentation.Alignment
+
 sealed class Shape {
     abstract val text: String
     abstract val classPath: String
@@ -7,17 +9,17 @@ sealed class Shape {
     abstract val pythonVariablePrefix: String
     val style = Style()
 
-    open fun getConstructor(): String {
+    override fun toString(): String {
         return "${className}(\"${text}\"$style).build()"
     }
 }
 
-data class Rectangle(
+class Rectangle(
     override val text: String,
-    val color: String? = null,
-    val textColor: String? = null,
-    val textWeight: String? = null,
-    val font: String? = null
+    private val color: String? = null,
+    private val textColor: String? = null,
+    private val textWeight: String? = null,
+    private val font: String? = null
 ) : Shape() {
     override val classPath: String = "python/rectangle.py"
     override val className: String = "Rectangle_block"
@@ -31,24 +33,48 @@ data class Rectangle(
     }
 }
 
-data class CodeBlockShape(
-    val lines: List<String>,
-    val textColor: String? = null,
-    val textWeight: String? = null,
-    val font: String? = null
+class CodeBlockShape(
+    lines: List<String>,
+    private val textColor: String? = null,
+    private val textWeight: String? = null,
+    private val font: String? = null
 ) : Shape() {
     override val classPath: String = "python/code_block.py"
     override val className: String = "Code_block"
     override val pythonVariablePrefix: String = "code_block"
     override val text: String = "[\"${lines.joinToString("\",\"")}\"]"
 
-    override fun getConstructor(): String {
-        return "${className}($text$style)"
-    }
-
     init {
         textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
         textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
         font?.let { style.addStyleAttribute(Font(font)) }
+    }
+
+    override fun toString(): String {
+        return "${className}($text$style)"
+    }
+}
+
+class InitStructureShape(
+    override val text: String,
+    private val alignment: Alignment,
+    private val color: String? = null,
+    private val textColor: String? = null,
+    private val textWeight: String? = null,
+    private val font: String? = null
+) : Shape() {
+    override val classPath: String = "python/init_structure.py"
+    override val className: String = "Init_structure"
+    override val pythonVariablePrefix: String = ""
+
+    init {
+        color?.let { style.addStyleAttribute(Color(color)) }
+        textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
+        textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
+        font?.let { style.addStyleAttribute(Font(font)) }
+    }
+
+    override fun toString(): String {
+        return "${className}(\"$text\", ${alignment.angle}$style).build()"
     }
 }

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -5,13 +5,10 @@ sealed class Shape {
     abstract val classPath: String
     abstract val className: String
     abstract val pythonVariablePrefix: String
+    val style = Style()
 
-    abstract fun getStyle(): Set<StyleAttribute>
-
-    fun getConstructor(): String {
-        val style = getStyle()
-        return "${className}(\"${text}\"" +
-                "${if (style.isNotEmpty()) ", ${style.joinToString(", ")}" else ""}).build()"
+    open fun getConstructor(): String {
+        return "${className}(\"${text}\"$style).build()"
     }
 }
 
@@ -26,13 +23,32 @@ data class Rectangle(
     override val className: String = "Rectangle_block"
     override val pythonVariablePrefix: String = "rectangle"
 
-    override fun getStyle(): Set<StyleAttribute> {
-        val style = mutableSetOf<StyleAttribute>()
-        color?.let { style.add(Color(color)) }
-        textColor?.let { style.add(TextColor(textColor)) }
-        textWeight?.let { style.add(TextWeight(textWeight)) }
-        font?.let { style.add(Font(font)) }
-        return style
+    init {
+        color?.let { style.addStyleAttribute(Color(color)) }
+        textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
+        textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
+        font?.let { style.addStyleAttribute(Font(font)) }
     }
 }
 
+data class CodeBlockShape(
+    val lines: List<String>,
+    val textColor: String? = null,
+    val textWeight: String? = null,
+    val font: String? = null
+) : Shape() {
+    override val classPath: String = "python/code_block.py"
+    override val className: String = "Code_block"
+    override val pythonVariablePrefix: String = "code_block"
+    override val text: String = "[\"${lines.joinToString("\",\"")}\"]"
+
+    override fun getConstructor(): String {
+        return "${className}($text$style)"
+    }
+
+    init {
+        textColor?.let { style.addStyleAttribute(TextColor(textColor)) }
+        textWeight?.let { style.addStyleAttribute(TextWeight(textWeight)) }
+        font?.let { style.addStyleAttribute(Font(font)) }
+    }
+}

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -1,15 +1,32 @@
 package com.manimdsl.shapes
 
-interface Shape {
-
-    val text: String
-    val classPath: String
-    val className: String
-    val pythonVariablePrefix: String
+sealed class Shape {
+    abstract val text: String
+    abstract val classPath: String
+    abstract val className: String
+    abstract val pythonVariablePrefix: String
+    open fun getStyle(): Set<StyleAttribute> = emptySet()
 }
 
-data class Rectangle(override val text: String) : Shape {
+data class Rectangle(
+    override val text: String,
+    val color: String? = null,
+    val textColor: String? = null,
+    val textWeight: String? = null,
+    val font: String? = null
+) : Shape() {
     override val classPath: String = "python/rectangle.py"
     override val className: String = "Rectangle_block"
     override val pythonVariablePrefix: String = "rectangle"
+
+    override fun getStyle(): Set<StyleAttribute> {
+        val style = mutableSetOf<StyleAttribute>()
+        color?.let { style.add(Color(color)) }
+        textColor?.let { style.add(TextColor(textColor)) }
+        textWeight?.let { style.add(TextWeight(textWeight)) }
+        font?.let { style.add(Font(font)) }
+        return style;
+    }
 }
+
+

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -29,4 +29,13 @@ data class Rectangle(
     }
 }
 
+data class InitStructure(
+    override val text: String,
+
+    ) : Shape() {
+    override val classPath: String = "python/init_structure.py"
+    override val className: String = "Init_structure"
+    override val pythonVariablePrefix = ""
+}
+
 

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -5,7 +5,14 @@ sealed class Shape {
     abstract val classPath: String
     abstract val className: String
     abstract val pythonVariablePrefix: String
-    open fun getStyle(): Set<StyleAttribute> = emptySet()
+
+    abstract fun getStyle(): Set<StyleAttribute>
+
+    fun getConstructor(): String {
+        val style = getStyle()
+        return "${className}(\"${text}\"" +
+                "${if (style.isNotEmpty()) ", ${style.joinToString(", ")}" else ""}).build()"
+    }
 }
 
 data class Rectangle(
@@ -25,17 +32,7 @@ data class Rectangle(
         textColor?.let { style.add(TextColor(textColor)) }
         textWeight?.let { style.add(TextWeight(textWeight)) }
         font?.let { style.add(Font(font)) }
-        return style;
+        return style
     }
 }
-
-data class InitStructure(
-    override val text: String,
-
-    ) : Shape() {
-    override val classPath: String = "python/init_structure.py"
-    override val className: String = "Init_structure"
-    override val pythonVariablePrefix = ""
-}
-
 

--- a/src/main/kotlin/com/manimdsl/shapes/Style.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Style.kt
@@ -23,19 +23,30 @@ sealed class ColorAttribute : StyleAttribute() {
     }
 }
 
-data class Color(override val value: String) : ColorAttribute() {
+class Color(override val value: String) : ColorAttribute() {
     override val name: String = "color"
 }
 
-data class TextColor(override val value: String) : ColorAttribute() {
+class TextColor(override val value: String) : ColorAttribute() {
     override val name: String = "text_color"
 }
 
-data class TextWeight(override val value: String) : StyleAttribute() {
+class TextWeight(override val value: String) : StyleAttribute() {
     override val name: String = "text_weight"
+    private val default = "NORMAL"
+    private val validWeights = setOf(default, "BOLD")
+
+    override fun toString(): String {
+        val upperCaseValue = value.toUpperCase()
+        return if (validWeights.contains(upperCaseValue)) {
+            "$name=$upperCaseValue"
+        } else {
+            "$name=$default"
+        }
+    }
 }
 
-data class Font(override val value: String) : StyleAttribute() {
+class Font(override val value: String) : StyleAttribute() {
     override val name: String = "font"
 
     override fun toString(): String = "$name=\"$value\""

--- a/src/main/kotlin/com/manimdsl/shapes/Style.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Style.kt
@@ -1,0 +1,42 @@
+package com.manimdsl.shapes
+
+sealed class StyleAttribute {
+    abstract val name: String
+    abstract val value: String
+
+    override fun toString(): String = "$name=$value"
+}
+
+sealed class ColorAttribute : StyleAttribute() {
+    private fun handleColourValue(): String {
+        return if (value.matches(Regex("#[a-fA-F0-9]{6}"))) {
+            // hex value
+            "\"${value}\""
+        } else {
+            // predefined constant
+            value.toUpperCase()
+        }
+    }
+
+    override fun toString(): String {
+        return "$name=${handleColourValue()}"
+    }
+}
+
+data class Color(override val value: String) : ColorAttribute() {
+    override val name: String = "color"
+}
+
+data class TextColor(override val value: String) : ColorAttribute() {
+    override val name: String = "text_color"
+}
+
+data class TextWeight(override val value: String) : StyleAttribute() {
+    override val name: String = "text_weight"
+}
+
+data class Font(override val value: String) : StyleAttribute() {
+    override val name: String = "font"
+
+    override fun toString(): String = "$name=\"$value\""
+}

--- a/src/main/kotlin/com/manimdsl/shapes/Style.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Style.kt
@@ -1,5 +1,19 @@
 package com.manimdsl.shapes
 
+class Style {
+    private val styleAttributes: MutableSet<StyleAttribute> = mutableSetOf()
+
+    fun addStyleAttribute(styleAttribute: StyleAttribute) {
+        styleAttributes.add(styleAttribute)
+    }
+
+    override fun toString(): String {
+        return if (styleAttributes.isNotEmpty()) {
+            ", ${styleAttributes.joinToString(", ")}"
+        } else ""
+    }
+}
+
 sealed class StyleAttribute {
     abstract val name: String
     abstract val value: String

--- a/src/main/resources/python/code_block.py
+++ b/src/main/resources/python/code_block.py
@@ -1,8 +1,8 @@
 class Code_block:
-    def __init__(self, code, color=WHITE):
+    def __init__(self, code, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
         group = VGroup()
         for c in code:
-            group.add(TextMobject(c, color=color))
+            group.add(Text(c, color=text_color, weight=text_weight, font=font))
         self.group = group
 
     def build(self):

--- a/src/main/resources/python/code_block.py
+++ b/src/main/resources/python/code_block.py
@@ -1,8 +1,8 @@
 class Code_block:
-    def __init__(self, code):
+    def __init__(self, code, color=WHITE):
         group = VGroup()
         for c in code:
-            group.add(TextMobject(c))
+            group.add(TextMobject(c, color=color))
         self.group = group
 
     def build(self):

--- a/src/main/resources/python/code_block.py
+++ b/src/main/resources/python/code_block.py
@@ -3,10 +3,10 @@ class Code_block:
         group = VGroup()
         for c in code:
             group.add(Text(c, color=text_color, weight=text_weight, font=font))
-        self.group = group
+        self.all = group
 
     def build(self):
-        return self.group.arrange(DOWN, aligned_edge=LEFT)
+        return self.all.arrange(DOWN, aligned_edge=LEFT)
 
     def get_line_at(self, line_number):
-        return self.group[line_number - 1]
+        return self.all[line_number - 1]

--- a/src/main/resources/python/init_structure.py
+++ b/src/main/resources/python/init_structure.py
@@ -1,18 +1,8 @@
 class Init_structure:
     def __init__(self, text, angle, length=1.5, color=WHITE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
-        self.text = text
-        self.angle = angle
-        self.length = length
-        self.color = color
-        self.text_color = text_color
-        self.text_weight = text_weight
-        self.font = font
-
-    def build(self):
-        line = Line(color=self.color)
-        line.set_length(self.length)
-        line.set_angle(self.angle)
-        label = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
-        label.next_to(line, DOWN, SMALL_BUFF)
-        group = VGroup(label, line)
-        return group
+        self.shape = Line(color=color)
+        self.shape.set_length(length)
+        self.shape.set_angle(angle)
+        self.text = Text(text, color=text_color, weight=text_weight, font=font)
+        self.text.next_to(self.shape, DOWN, SMALL_BUFF)
+        self.all = VGroup(self.text, self.shape)

--- a/src/main/resources/python/init_structure.py
+++ b/src/main/resources/python/init_structure.py
@@ -1,15 +1,18 @@
 class Init_structure:
-    def __init__(self, text, angle, length=1.5, color=WHITE):
+    def __init__(self, text, angle, length=1.5, color=WHITE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
         self.text = text
         self.angle = angle
         self.length = length
         self.color = color
+        self.text_color = text_color
+        self.text_weight = text_weight
+        self.font = font
 
     def build(self):
         line = Line(color=self.color)
         line.set_length(self.length)
         line.set_angle(self.angle)
-        label = TextMobject(self.text, color=self.color)
+        label = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
         label.next_to(line, DOWN, SMALL_BUFF)
         group = VGroup(label, line)
         return group

--- a/src/main/resources/python/rectangle.py
+++ b/src/main/resources/python/rectangle.py
@@ -1,15 +1,5 @@
 class Rectangle_block:
     def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
-        self.text   = text
-        self.height = height
-        self.width  = width
-        self.color  = color
-        self.text_color  = text_color
-        self.text_weight = text_weight
-        self.font   = font
-
-    def build(self):
-        inside_text = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
-        rectangle   = Rectangle(height=self.height, width=self.width, color=self.color)
-        group       = VGroup(inside_text, rectangle)
-        return group
+        self.text = Text(text, color=text_color, weight=text_weight, font=font)
+        self.shape = Rectangle(height=height, width=width, color=color)
+        self.all = VGroup(self.text, self.shape)

--- a/src/main/resources/python/rectangle.py
+++ b/src/main/resources/python/rectangle.py
@@ -1,13 +1,15 @@
 class Rectangle_block:
-    def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE):
+    def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
         self.text   = text
         self.height = height
         self.width  = width
         self.color  = color
-        self.text_color = text_color
+        self.text_color  = text_color
+        self.text_weight = text_weight
+        self.font   = font
 
     def build(self):
-        inside_text = TextMobject(self.text, color=self.text_color)
+        inside_text = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
         rectangle   = Rectangle(height=self.height, width=self.width, color=self.color)
         group       = VGroup(inside_text, rectangle)
         return group

--- a/src/main/resources/python/rectangle.py
+++ b/src/main/resources/python/rectangle.py
@@ -1,12 +1,13 @@
 class Rectangle_block:
-    def __init__(self, text, height=0.75, width=1.5, color=BLUE):
+    def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE):
         self.text   = text
         self.height = height
         self.width  = width
         self.color  = color
+        self.text_color = text_color
 
     def build(self):
-        inside_text = TextMobject(self.text)
+        inside_text = TextMobject(self.text, color=self.text_color)
         rectangle   = Rectangle(height=self.height, width=self.width, color=self.color)
         group       = VGroup(inside_text, rectangle)
         return group

--- a/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
@@ -32,7 +32,7 @@ class ASTExecutorTests {
                     ),
                     MoveToLine(lineNumber = 1, pointerName = "pointer", codeBlockName = "code_block"),
                     MoveToLine(lineNumber = 2, pointerName = "pointer", codeBlockName = "code_block"),
-                    InitStructure(x = 2, y = -1, alignment = Alignment.HORIZONTAL, ident = "empty", text = "y")
+                    InitStructure(Coordinate(2, -1), alignment = Alignment.HORIZONTAL, ident = "empty", text = "y")
                 )
             )
         )

--- a/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
@@ -32,7 +32,7 @@ class ASTExecutorTests {
                     ),
                     MoveToLine(lineNumber = 1, pointerName = "pointer", codeBlockName = "code_block"),
                     MoveToLine(lineNumber = 2, pointerName = "pointer", codeBlockName = "code_block"),
-                    InitStructure(Coordinate(2, -1), alignment = Alignment.HORIZONTAL, ident = "empty", text = "y")
+                    InitStructure(Coord(2.0, -1.0), alignment = Alignment.HORIZONTAL, ident = "empty", text = "y")
                 )
             )
         )

--- a/src/test/kotlin/com/manimdsl/linearrepresentation/StyleTests.kt
+++ b/src/test/kotlin/com/manimdsl/linearrepresentation/StyleTests.kt
@@ -14,12 +14,12 @@ class StyleTests {
         val textColor = "black"
         val textWeight = "normal"
         val font = "TestFont"
-        val rectangle = Rectangle("rectangle", color, textColor, textWeight, font)
+        val rectangle = Rectangle("x", "rectangle", color, textColor, textWeight, font)
 
-        val mobject = NewMObject(rectangle, "x", "codeBlock")
+        val mobject = NewMObject(rectangle, "codeBlock")
 
         val expected =
-            "x = Rectangle_block(\"rectangle\", color=${color.toUpperCase()}, text_color=${textColor.toUpperCase()}, text_weight=${textWeight.toUpperCase()}, font=\"$font\").build()"
+            "x = Rectangle_block(\"rectangle\", color=${color.toUpperCase()}, text_color=${textColor.toUpperCase()}, text_weight=${textWeight.toUpperCase()}, font=\"$font\")"
         assertEquals(expected, mobject.toPython()[0])
     }
 
@@ -28,12 +28,12 @@ class StyleTests {
 
         val color = "#ffffff"
         val textColor = "#ffffff"
-        val rectangle = Rectangle("rectangle", color, textColor)
+        val rectangle = Rectangle("x", "rectangle", color, textColor)
 
-        val mobject = NewMObject(rectangle, "x", "codeBlock")
+        val mobject = NewMObject(rectangle, "codeBlock")
 
         val expected =
-            "x = Rectangle_block(\"rectangle\", color=\"$color\", text_color=\"$textColor\").build()"
+            "x = Rectangle_block(\"rectangle\", color=\"$color\", text_color=\"$textColor\")"
         assertEquals(expected, mobject.toPython()[0])
     }
 
@@ -41,12 +41,12 @@ class StyleTests {
     fun invalidTextWeightsAreReturnedToDefault() {
 
         val textWeight = "invalid"
-        val rectangle = Rectangle("rectangle", textWeight = textWeight)
+        val rectangle = Rectangle("x", "rectangle", textWeight = textWeight)
 
-        val mobject = NewMObject(rectangle, "x", "codeBlock")
+        val mobject = NewMObject(rectangle, "codeBlock")
 
         val expected =
-            "x = Rectangle_block(\"rectangle\", text_weight=NORMAL).build()"
+            "x = Rectangle_block(\"rectangle\", text_weight=NORMAL)"
         assertEquals(expected, mobject.toPython()[0])
     }
 }

--- a/src/test/kotlin/com/manimdsl/linearrepresentation/StyleTests.kt
+++ b/src/test/kotlin/com/manimdsl/linearrepresentation/StyleTests.kt
@@ -1,0 +1,52 @@
+package com.manimdsl.linearrepresentation
+
+import com.manimdsl.shapes.Rectangle
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+
+
+class StyleTests {
+
+    @Test
+    fun stylesAreMappedToPythonCorrectly() {
+
+        val color = "white"
+        val textColor = "black"
+        val textWeight = "normal"
+        val font = "TestFont"
+        val rectangle = Rectangle("rectangle", color, textColor, textWeight, font)
+
+        val mobject = NewMObject(rectangle, "x", "codeBlock")
+
+        val expected =
+            "x = Rectangle_block(\"rectangle\", color=${color.toUpperCase()}, text_color=${textColor.toUpperCase()}, text_weight=${textWeight.toUpperCase()}, font=\"$font\").build()"
+        assertEquals(expected, mobject.toPython()[0])
+    }
+
+    @Test
+    fun hexadecimalColorsAreMappedCorrectly() {
+
+        val color = "#ffffff"
+        val textColor = "#ffffff"
+        val rectangle = Rectangle("rectangle", color, textColor)
+
+        val mobject = NewMObject(rectangle, "x", "codeBlock")
+
+        val expected =
+            "x = Rectangle_block(\"rectangle\", color=\"$color\", text_color=\"$textColor\").build()"
+        assertEquals(expected, mobject.toPython()[0])
+    }
+
+    @Test
+    fun invalidTextWeightsAreReturnedToDefault() {
+
+        val textWeight = "invalid"
+        val rectangle = Rectangle("rectangle", textWeight = textWeight)
+
+        val mobject = NewMObject(rectangle, "x", "codeBlock")
+
+        val expected =
+            "x = Rectangle_block(\"rectangle\", text_weight=NORMAL).build()"
+        assertEquals(expected, mobject.toPython()[0])
+    }
+}

--- a/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
+++ b/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
@@ -34,10 +34,6 @@ class TestLinearRepresentation {
         val expected = File("src/test/testFiles/python/stack.py").readLines()
         val generated = File(writer.createPythonFile()).readLines()
 
-
-        assertEquals(
-            expected.filter { it.trim() != "" }.joinToString("\n"),
-            generated.filter { it.trim() != "" }.joinToString("\n")
-        )
+        assertEquals(expected, generated)
     }
 }

--- a/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
+++ b/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
@@ -18,7 +18,7 @@ class TestLinearRepresentation {
         val stackIR = listOf(
             CodeBlock(codeBlock, "code_block", "code_text", "pointer"),
             MoveToLine(1, "pointer", "code_block"),
-            InitStructure(2, -1, Alignment.HORIZONTAL, "empty", "y"),
+            InitStructure(Coordinate(2, -1), Alignment.HORIZONTAL, "empty", "y"),
             NewMObject(Rectangle("2"), "testIdent", "code_text"),
             MoveToLine(2, "pointer", "code_block"),
             MoveObject("testIdent", "empty", ObjectSide.ABOVE),

--- a/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
+++ b/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
@@ -18,7 +18,7 @@ class TestLinearRepresentation {
         val stackIR = listOf(
             CodeBlock(codeBlock, "code_block", "code_text", "pointer"),
             MoveToLine(1, "pointer", "code_block"),
-            InitStructure(Coordinate(2, -1), Alignment.HORIZONTAL, "empty", "y"),
+            InitStructure(Coord(2.0, -1.0), Alignment.HORIZONTAL, "empty", "y"),
             NewMObject(Rectangle("2"), "testIdent", "code_text"),
             MoveToLine(2, "pointer", "code_block"),
             MoveObject("testIdent", "empty", ObjectSide.ABOVE),
@@ -34,6 +34,9 @@ class TestLinearRepresentation {
         val expected = File("src/test/testFiles/python/stack.py").readLines()
         val generated = File(writer.createPythonFile()).readLines()
 
-        assertEquals(expected, generated)
+        assertEquals(
+            expected.filter { it.trim() != "" }.joinToString("\n"),
+            generated.filter { it.trim() != "" }.joinToString("\n")
+        )
     }
 }

--- a/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
+++ b/src/test/kotlin/com/manimdsl/linearrepresentation/TestLinearRepresentation.kt
@@ -14,19 +14,22 @@ class TestLinearRepresentation {
     fun mockStackLinearRepresentation() {
 
         val codeBlock = listOf("let y = new Stack;", "y.push(2);", "y.push(3);", "y.pop();")
+        val testIdent = Rectangle("testIdent", "2")
+        val testIdent1 = Rectangle("testIdent1", "3")
+        val stackIS = InitStructure(Coord(2.0, -1.0), Alignment.HORIZONTAL, "empty", "y")
 
         val stackIR = listOf(
             CodeBlock(codeBlock, "code_block", "code_text", "pointer"),
             MoveToLine(1, "pointer", "code_block"),
-            InitStructure(Coord(2.0, -1.0), Alignment.HORIZONTAL, "empty", "y"),
-            NewMObject(Rectangle("2"), "testIdent", "code_text"),
+            stackIS,
+            NewMObject(testIdent, "code_text"),
             MoveToLine(2, "pointer", "code_block"),
-            MoveObject("testIdent", "empty", ObjectSide.ABOVE),
+            MoveObject(testIdent, stackIS.shape, ObjectSide.ABOVE),
             MoveToLine(3, "pointer", "code_block"),
-            NewMObject(Rectangle("3"), "testIdent1", "code_text"),
-            MoveObject("testIdent1", "testIdent", ObjectSide.ABOVE),
+            NewMObject(testIdent1, "code_text"),
+            MoveObject(testIdent1, testIdent, ObjectSide.ABOVE),
             MoveToLine(4, "pointer", "code_block"),
-            MoveObject("testIdent1", "testIdent", ObjectSide.ABOVE, 20, true),
+            MoveObject(testIdent1, testIdent, ObjectSide.ABOVE, 20, true),
         )
 
         val writer = ManimProjectWriter(ManimWriter(stackIR).build())

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -8,22 +8,22 @@ class Main(Scene):
         self.play(FadeIn(code_text))
         pointer = ArrowTip(color=YELLOW).scale(0.7).flip(TOP)
         self.move_arrow_to_line(1, pointer, code_block)
-        empty = Init_structure("y", 0).build()
-        empty.to_edge(np.array([2.0, -1.0, 0]))
-        self.play(ShowCreation(empty))
-        testIdent = Rectangle_block("2").build()
-        self.place_relative_to_obj(testIdent, code_text, 0.25, 0.0)
-        self.play(FadeIn(testIdent))
+        empty = Init_structure("y", 0)
+        empty.all.to_edge(np.array([2.0, -1.0, 0]))
+        self.play(ShowCreation(empty.all))
+        testIdent = Rectangle_block("2")
+        self.place_relative_to_obj(testIdent.all, code_text, 0.25, 0.0)
+        self.play(FadeIn(testIdent.all))
         self.move_arrow_to_line(2, pointer, code_block)
-        self.move_relative_to_obj(testIdent, empty, 0.0, 0.25)
+        self.move_relative_to_obj(testIdent.all, empty.all, 0.0, 0.25)
         self.move_arrow_to_line(3, pointer, code_block)
-        testIdent1 = Rectangle_block("3").build()
-        self.place_relative_to_obj(testIdent1, code_text, 0.25, 0.0)
-        self.play(FadeIn(testIdent1))
-        self.move_relative_to_obj(testIdent1, testIdent, 0.0, 0.25)
+        testIdent1 = Rectangle_block("3")
+        self.place_relative_to_obj(testIdent1.all, code_text, 0.25, 0.0)
+        self.play(FadeIn(testIdent1.all))
+        self.move_relative_to_obj(testIdent1.all, testIdent.all, 0.0, 0.25)
         self.move_arrow_to_line(4, pointer, code_block)
-        self.move_relative_to_obj(testIdent1, testIdent, 0.0, 20.25)
-        self.play(FadeOut(testIdent1))
+        self.move_relative_to_obj(testIdent1.all, testIdent.all, 0.0, 20.25)
+        self.play(FadeOut(testIdent1.all))
     def place_at(self, group, x, y):
         group.to_edge(np.array([x, y, 0]))
     
@@ -46,45 +46,25 @@ class Code_block:
         group = VGroup()
         for c in code:
             group.add(Text(c, color=text_color, weight=text_weight, font=font))
-        self.group = group
+        self.all = group
 
     def build(self):
-        return self.group.arrange(DOWN, aligned_edge=LEFT)
+        return self.all.arrange(DOWN, aligned_edge=LEFT)
 
     def get_line_at(self, line_number):
-        return self.group[line_number - 1]
+        return self.all[line_number - 1]
 
 class Init_structure:
     def __init__(self, text, angle, length=1.5, color=WHITE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
-        self.text = text
-        self.angle = angle
-        self.length = length
-        self.color = color
-        self.text_color = text_color
-        self.text_weight = text_weight
-        self.font = font
-
-    def build(self):
-        line = Line(color=self.color)
-        line.set_length(self.length)
-        line.set_angle(self.angle)
-        label = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
-        label.next_to(line, DOWN, SMALL_BUFF)
-        group = VGroup(label, line)
-        return group
+        self.shape = Line(color=color)
+        self.shape.set_length(length)
+        self.shape.set_angle(angle)
+        self.text = Text(text, color=text_color, weight=text_weight, font=font)
+        self.text.next_to(self.shape, DOWN, SMALL_BUFF)
+        self.all = VGroup(self.text, self.shape)
 
 class Rectangle_block:
     def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
-        self.text   = text
-        self.height = height
-        self.width  = width
-        self.color  = color
-        self.text_color  = text_color
-        self.text_weight = text_weight
-        self.font   = font
-
-    def build(self):
-        inside_text = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
-        rectangle   = Rectangle(height=self.height, width=self.width, color=self.color)
-        group       = VGroup(inside_text, rectangle)
-        return group
+        self.text = Text(text, color=text_color, weight=text_weight, font=font)
+        self.shape = Rectangle(height=height, width=width, color=color)
+        self.all = VGroup(self.text, self.shape)

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -1,4 +1,5 @@
 from manimlib.imports import *
+ 
 class Main(Scene):
     def construct(self):
         code_block = Code_block(["let y = new Stack;","y.push(2);","y.push(3);","y.pop();"])
@@ -25,31 +26,41 @@ class Main(Scene):
         self.play(FadeOut(testIdent1))
     def place_at(self, group, x, y):
         group.to_edge(np.array([x, y, 0]))
+    
     def move_relative_to_edge(self, group, x, y):
         self.play(ApplyMethod(group.to_edge, np.array([x, y, 0])))
+    
     def move_relative_to_obj(self, group, target, x, y):
         self.play(ApplyMethod(group.next_to, target, np.array([x, y, 0])))
+    
     def place_relative_to_obj(self, group, target, x, y):
         group.next_to(target, np.array([x, y, 0]))
+    
     def move_arrow_to_line(self, line_number, pointer, code_block):
         line_object = code_block.get_line_at(line_number)
         self.play(FadeIn(pointer.next_to(line_object, LEFT, MED_SMALL_BUFF)))
+    
+    
 class Code_block:
-    def __init__(self, code):
+    def __init__(self, code, color=WHITE):
         group = VGroup()
         for c in code:
-            group.add(TextMobject(c))
+            group.add(TextMobject(c, color=color))
         self.group = group
+
     def build(self):
         return self.group.arrange(DOWN, aligned_edge=LEFT)
+
     def get_line_at(self, line_number):
         return self.group[line_number - 1]
+
 class Init_structure:
     def __init__(self, text, angle, length=1.5, color=WHITE):
         self.text = text
         self.angle = angle
         self.length = length
         self.color = color
+
     def build(self):
         line = Line(color=self.color)
         line.set_length(self.length)
@@ -58,14 +69,17 @@ class Init_structure:
         label.next_to(line, DOWN, SMALL_BUFF)
         group = VGroup(label, line)
         return group
+
 class Rectangle_block:
-    def __init__(self, text, height=0.75, width=1.5, color=BLUE):
+    def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE):
         self.text   = text
         self.height = height
         self.width  = width
         self.color  = color
+        self.text_color = text_color
+
     def build(self):
-        inside_text = TextMobject(self.text)
+        inside_text = TextMobject(self.text, color=self.text_color)
         rectangle   = Rectangle(height=self.height, width=self.width, color=self.color)
         group       = VGroup(inside_text, rectangle)
         return group

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -42,10 +42,10 @@ class Main(Scene):
     
     
 class Code_block:
-    def __init__(self, code, color=WHITE):
+    def __init__(self, code, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
         group = VGroup()
         for c in code:
-            group.add(TextMobject(c, color=color))
+            group.add(Text(c, color=text_color, weight=text_weight, font=font))
         self.group = group
 
     def build(self):
@@ -55,31 +55,36 @@ class Code_block:
         return self.group[line_number - 1]
 
 class Init_structure:
-    def __init__(self, text, angle, length=1.5, color=WHITE):
+    def __init__(self, text, angle, length=1.5, color=WHITE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
         self.text = text
         self.angle = angle
         self.length = length
         self.color = color
+        self.text_color = text_color
+        self.text_weight = text_weight
+        self.font = font
 
     def build(self):
         line = Line(color=self.color)
         line.set_length(self.length)
         line.set_angle(self.angle)
-        label = TextMobject(self.text, color=self.color)
+        label = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
         label.next_to(line, DOWN, SMALL_BUFF)
         group = VGroup(label, line)
         return group
 
 class Rectangle_block:
-    def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE):
+    def __init__(self, text, height=0.75, width=1.5, color=BLUE, text_color=WHITE, text_weight=NORMAL, font="Times New Roman"):
         self.text   = text
         self.height = height
         self.width  = width
         self.color  = color
-        self.text_color = text_color
+        self.text_color  = text_color
+        self.text_weight = text_weight
+        self.font   = font
 
     def build(self):
-        inside_text = TextMobject(self.text, color=self.text_color)
+        inside_text = Text(self.text, color=self.text_color, weight=self.text_weight, font=self.font)
         rectangle   = Rectangle(height=self.height, width=self.width, color=self.color)
         group       = VGroup(inside_text, rectangle)
         return group

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -9,7 +9,7 @@ class Main(Scene):
         pointer = ArrowTip(color=YELLOW).scale(0.7).flip(TOP)
         self.move_arrow_to_line(1, pointer, code_block)
         empty = Init_structure("y", 0).build()
-        empty.to_edge(np.array([2, -1, 0]))
+        empty.to_edge(np.array([2.0, -1.0, 0]))
         self.play(ShowCreation(empty))
         testIdent = Rectangle_block("2").build()
         self.place_relative_to_obj(testIdent, code_text, 0.25, 0.0)


### PR DESCRIPTION
### Clubhouse Ticket
[ch132](https://app.clubhouse.io/manim-dsl/story/132/extend-ir-python-library-to-take-customisable-inputs)

### Description

Extended the Python classes `Rectangle`, `Code_block` and `Init_structure` to take color, and text properties. I then updated the Shape classes to take these properties. Implemented `StyleAttribute` and `Style` classes to handle and validate styles to only those which we support.

I have recently updated the python library to expose the constituent Manim objects that make up each shape. This is so that all or some can be modified in terms of colour etc. So in case of a rectangle you move the whole object with `rectangle.all` and can target just the text e.g. `rectangle.text.setColor(BLUE)`. The Kotlin Shape classes handle this nicely, with getters for the constituent objects and by default their `toString` methods return `$ident.all` referring to the whole VGroup in the object.

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update - potentially when style sheet is implemented

### How Has This Been Tested?

Implemented tests to see if python produced is correct and if validation occurs.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules