### PR TITLE
Added CLI options 

### DIFF
--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -99,8 +99,8 @@ class DSLCommandLineArguments : Callable<Int> {
         }
     }
 
-    @Option(names = ["-f", "--show_file_in_finder"], description = ["Show the output file in finder."])
-    fun show_file_in_finder(showFile: Boolean = false) {
+    @Option(names = ["-f", "--open_file_manager_to_generated_files"], description = ["Show the output file in file manager."])
+    fun open_file_manager_to_generated_files(showFile: Boolean = false) {
         if (showFile) manimArguments.add("-f")
     }
 

--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -84,7 +84,7 @@ class DSLCommandLineArguments : Callable<Int> {
     @Option(names = ["-p", "--python"], description = ["Output generated python & manim code (optional)."])
     var python: Boolean = false
 
-    @Option(names = ["-m", "--manim"], description = ["Only output generated python & manim code."])
+    @Option(names = ["-m", "--manim"], description = ["Only output generated python & manim code (optional)."])
     var manim: Boolean = false
 
     @Option(
@@ -99,12 +99,12 @@ class DSLCommandLineArguments : Callable<Int> {
         }
     }
 
-    @Option(names = ["-f", "--open_file_manager_to_generated_files"], description = ["Show the output file in file manager."])
+    @Option(names = ["-f", "--open_file_manager_to_generated_files"], description = ["Show the output file in file manager (optional)."])
     fun open_file_manager_to_generated_files(showFile: Boolean = false) {
         if (showFile) manimArguments.add("-f")
     }
 
-    @Option(names = ["--preview"], description = ["Automatically open the saved file once its done."])
+    @Option(names = ["--preview"], description = ["Automatically open the saved file once its done (optional)."])
     fun open_file(open_file: Boolean = false) {
         if (open_file) manimArguments.add("-p")
     }

--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -99,13 +99,13 @@ class DSLCommandLineArguments : Callable<Int> {
         }
     }
 
-    @Option(names = ["-f", "--open_file_manager_to_generated_files"], description = ["Show the output file in file manager (optional)."])
-    fun open_file_manager_to_generated_files(showFile: Boolean = false) {
+    @Option(names = ["-f", "--open_file"], description = ["Show the output file in file manager (optional)."])
+    fun open_file(showFile: Boolean = false) {
         if (showFile) manimArguments.add("-f")
     }
 
     @Option(names = ["--preview"], description = ["Automatically open the saved file once its done (optional)."])
-    fun open_file(open_file: Boolean = false) {
+    fun preview(open_file: Boolean = false) {
         if (open_file) manimArguments.add("-p")
     }
 

--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -116,3 +116,4 @@ class DSLCommandLineArguments : Callable<Int> {
 }
 
 fun main(args: Array<String>): Unit = exitProcess(CommandLine(DSLCommandLineArguments()).execute(*args))
+

--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -69,28 +69,28 @@ enum class AnimationQuality {
     name = "manimdsl",
     mixinStandardHelpOptions = true,
     version = ["manimdsl 1.0"],
-    description = ["ManimDSL compiler to produce manim animations"]
+    description = ["ManimDSL compiler to produce manim animations."]
 )
 class DSLCommandLineArguments : Callable<Int> {
 
     private val manimArguments = mutableListOf<String>()
 
-    @Parameters(index = "0", description = ["The manimdsl file to compile and animate"])
+    @Parameters(index = "0", description = ["The manimdsl file to compile and animate."])
     lateinit var file: String
 
-    @Option(names = ["-o", "--output"], description = ["The animated mp4 file location (default: \${DEFAULT-VALUE})"])
+    @Option(names = ["-o", "--output"], description = ["The animated mp4 file location (default: \${DEFAULT-VALUE})."])
     var output: String = "out.mp4"
 
-    @Option(names = ["-p", "--python"], description = ["Output generated python & manim code (optional)"])
+    @Option(names = ["-p", "--python"], description = ["Output generated python & manim code (optional)."])
     var python: Boolean = false
 
-    @Option(names = ["-m", "--manim"], description = ["Only output generated python & manim code"])
+    @Option(names = ["-m", "--manim"], description = ["Only output generated python & manim code."])
     var manim: Boolean = false
 
     @Option(
         names = ["-q", "--quality"],
         defaultValue = "low",
-        description = ["Quality of animation. [\${COMPLETION-CANDIDATES}] (default: \${DEFAULT-VALUE})"]
+        description = ["Quality of animation. [\${COMPLETION-CANDIDATES}] (default: \${DEFAULT-VALUE})."]
     )
     fun quality(quality: AnimationQuality = AnimationQuality.LOW) {
         when (quality) {
@@ -99,12 +99,12 @@ class DSLCommandLineArguments : Callable<Int> {
         }
     }
 
-    @Option(names = ["-f", "--show_file_in_finder"], description = ["Show the output file in finder"])
+    @Option(names = ["-f", "--show_file_in_finder"], description = ["Show the output file in finder."])
     fun show_file_in_finder(showFile: Boolean = false) {
         if (showFile) manimArguments.add("-f")
     }
 
-    @Option(names = ["--preview"], description = ["Automatically open the saved file once its done"])
+    @Option(names = ["--preview"], description = ["Automatically open the saved file once its done."])
     fun open_file(open_file: Boolean = false) {
         if (open_file) manimArguments.add("-p")
     }


### PR DESCRIPTION
Added CLI options for: show file in finder, preview the video automatically, and only generate manim code im Compiler.kt


### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

Tried it locally. The only thing to double check is the --preview option. It opens QuickTime Player on my laptop but not the video. But, I've tried it only Manim directly and it does the same. To test on non Macs.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules