### PR TITLE
Feature/ch168/extend stack to include size and isempty

### DIFF
--- a/example.manimdsl
+++ b/example.manimdsl
@@ -3,4 +3,8 @@ let stack2 = new Stack<number>;
 if (false == false) {
     stack1.push(1);
 }
-stack2.push(stack1.pop());
+
+
+if(stack1.size() == 2) {
+    stack2.push(stack1.pop());
+}

--- a/example.manimdsl
+++ b/example.manimdsl
@@ -1,6 +1,6 @@
 let stack1 = new Stack<number>;
 let stack2 = new Stack<number>;
-stack1.push(1);
-stack1.push(2);
-stack1.push(3);
+if (false == false) {
+    stack1.push(1);
+}
 stack2.push(stack1.pop());

--- a/src/main/kotlin/com/manimdsl/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/ASTExecutor.kt
@@ -216,6 +216,11 @@ class VirtualMachine(
                         is StackType.SizeMethod -> {
                             return DoubleValue(ds.stack.size.toDouble())
                         }
+                        is StackType.PeekMethod -> {
+                            val clonedPeekValue = ds.stack.peek().clone()
+                            clonedPeekValue.manimObject = EmptyMObject
+                            return clonedPeekValue
+                        }
                         else -> EmptyValue
                     }
                 }

--- a/src/main/kotlin/com/manimdsl/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/ASTExecutor.kt
@@ -210,6 +210,12 @@ class VirtualMachine(
                             linearRepresentation.addAll(instructions)
                             return poppedValue
                         }
+                        is StackType.IsEmptyMethod -> {
+                            return BoolValue(ds.stack.isEmpty())
+                        }
+                        is StackType.SizeMethod -> {
+                            return DoubleValue(ds.stack.size.toDouble())
+                        }
                         else -> EmptyValue
                     }
                 }

--- a/src/main/kotlin/com/manimdsl/executor/ExecValue.kt
+++ b/src/main/kotlin/com/manimdsl/executor/ExecValue.kt
@@ -51,10 +51,9 @@ sealed class ExecValue {
 
 data class DoubleValue(override val value: Double, override var manimObject: MObject = EmptyMObject) : ExecValue() {
     override fun equals(other: Any?): Boolean = other is DoubleValue && this.value == other.value
+
     override fun hashCode(): Int {
-        var result = value.hashCode()
-        result = 31 * result + manimObject.hashCode()
-        return result
+        return value.hashCode()
     }
 
     override fun clone(): ExecValue {

--- a/src/main/kotlin/com/manimdsl/frontend/Type.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/Type.kt
@@ -47,7 +47,7 @@ data class StackType(
             argumentTypes = listOf(
                 internalType,
             )
-        ), "pop" to PopMethod(internalType)
+        ), "pop" to PopMethod(internalType), "isEmpty" to IsEmptyMethod(), "size" to SizeMethod()
     )
 ) : DataStructureType(internalType, methods) {
 
@@ -55,6 +55,18 @@ data class StackType(
         DataStructureMethod
 
     data class PopMethod(override val returnType: Type, override var argumentTypes: List<Type> = listOf()) :
+        DataStructureMethod
+
+    data class IsEmptyMethod(
+        override val returnType: Type = BoolType,
+        override var argumentTypes: List<Type> = listOf()
+    ) :
+        DataStructureMethod
+
+    data class SizeMethod(
+        override val returnType: Type = NumberType,
+        override var argumentTypes: List<Type> = listOf()
+    ) :
         DataStructureMethod
 
     override fun containsMethod(method: String): Boolean {
@@ -72,7 +84,7 @@ data class StackType(
 
 
 object ErrorType : Type()
-object VoidType: Type() {
+object VoidType : Type() {
     override fun toString(): String {
         return "void"
     }

--- a/src/main/kotlin/com/manimdsl/frontend/Type.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/Type.kt
@@ -47,7 +47,7 @@ data class StackType(
             argumentTypes = listOf(
                 internalType,
             )
-        ), "pop" to PopMethod(internalType), "isEmpty" to IsEmptyMethod(), "size" to SizeMethod()
+        ), "pop" to PopMethod(internalType), "isEmpty" to IsEmptyMethod(), "size" to SizeMethod(),  "peek" to PeekMethod(internalType)
     )
 ) : DataStructureType(internalType, methods) {
 
@@ -60,13 +60,14 @@ data class StackType(
     data class IsEmptyMethod(
         override val returnType: Type = BoolType,
         override var argumentTypes: List<Type> = listOf()
-    ) :
-        DataStructureMethod
+    ) : DataStructureMethod
 
     data class SizeMethod(
         override val returnType: Type = NumberType,
         override var argumentTypes: List<Type> = listOf()
-    ) :
+    ) : DataStructureMethod
+
+    data class PeekMethod(override val returnType: Type, override var argumentTypes: List<Type> = listOf()) :
         DataStructureMethod
 
     override fun containsMethod(method: String): Boolean {


### PR DESCRIPTION
### Clubhouse Ticket
[ch168]({https://app.clubhouse.io/manim-dsl/story/168/extend-stack-to-include-size-and-isempty-peek})

### Description

Added size, is empty and peek to stack 

Fixes # (issue) 

### Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules