### PR TITLE
Implement array on compiler frontend

### DIFF
--- a/antlr_config/ManimLexer.g4
+++ b/antlr_config/ManimLexer.g4
@@ -30,6 +30,9 @@ OPEN_PARENTHESIS: '(' ;
 CLOSE_PARENTHESIS: ')' ;
 OPEN_CURLY_BRACKET: '{';
 CLOSE_CURLY_BRACKET: '}';
+OPEN_SQUARE_BRACKET: '[';
+CLOSE_SQUARE_BRACKET: ']';
+
 CODE_COMMENT: '#' ~('\n' | '\r')* ('\n' | '\r')? -> skip;
 LET: 'let';
 FUN: 'fun';
@@ -44,6 +47,7 @@ NEW: 'new';
 COMMENT: 'comment';
 SLEEP: 'sleep';
 STACK: 'Stack';
+ARRAY: 'Array';
 IF: 'if';
 ELSE: 'else';
 

--- a/antlr_config/ManimLexer.g4
+++ b/antlr_config/ManimLexer.g4
@@ -43,7 +43,6 @@ NUMBER_TYPE: 'number';
 BOOL_TYPE: 'boolean';
 
 // Keywords
-NEW: 'new';
 COMMENT: 'comment';
 SLEEP: 'sleep';
 STACK: 'Stack';

--- a/antlr_config/ManimParser.g4
+++ b/antlr_config/ManimParser.g4
@@ -35,9 +35,9 @@ expr: NUMBER                                                        #NumberLiter
     | bool                                                          #BooleanLiteral
     | IDENT                                                         #Identifier
     | array_elem                                                    #ArrayElemExpr
-    | NEW data_structure_type
+    | data_structure_type
     OPEN_PARENTHESIS arg_list? CLOSE_PARENTHESIS
-    data_structure_initialiser?                                     #DataStructureContructor
+    data_structure_initialiser?                                     #DataStructureConstructor
     | method_call                                                   #MethodCallExpression
     | unary_operator=(ADD | MINUS | NOT) expr                       #UnaryOperator
     | left=expr binary_operator=(ADD | MINUS | TIMES) right=expr    #BinaryExpression

--- a/antlr_config/ManimParser.g4
+++ b/antlr_config/ManimParser.g4
@@ -15,7 +15,7 @@ param: IDENT COLON type                                                  #Parame
 stat: SLEEP OPEN_PARENTHESIS expr CLOSE_PARENTHESIS SEMI                 #SleepStatement
     | COMMENT OPEN_PARENTHESIS STRING CLOSE_PARENTHESIS SEMI             #CommentStatement // when string type defined we can adjust
     | LET IDENT (COLON type)? EQUAL expr SEMI                            #DeclarationStatement
-    | IDENT EQUAL expr SEMI                                              #AssignmentStatement
+    | assignment_lhs EQUAL expr SEMI                                     #AssignmentStatement
     | IF OPEN_PARENTHESIS ifCond=expr CLOSE_PARENTHESIS
     OPEN_CURLY_BRACKET ifStat=stat? CLOSE_CURLY_BRACKET
      elseIf*
@@ -24,6 +24,8 @@ stat: SLEEP OPEN_PARENTHESIS expr CLOSE_PARENTHESIS SEMI                 #SleepS
     | method_call SEMI                                                   #MethodCallStatement
     | RETURN expr? SEMI                                                  #ReturnStatement;
 
+assignment_lhs: IDENT           #IdentifierAssignment
+    | array_access              #ArrayAccessAssignment;
 
 elseIf: ELSE IF OPEN_PARENTHESIS elifCond=expr CLOSE_PARENTHESIS OPEN_CURLY_BRACKET elifStat=stat? CLOSE_CURLY_BRACKET;
 
@@ -32,6 +34,7 @@ arg_list: expr (COMMA expr)*                                        #ArgumentLis
 expr: NUMBER                                                        #NumberLiteral
     | bool                                                          #BooleanLiteral
     | IDENT                                                         #Identifier
+    | array_access                                                  #ArrayAccessExpr
     | NEW data_structure_type                                       #DataStructureContructor
     | method_call                                                   #MethodCallExpression
     | unary_operator=(ADD | MINUS | NOT) expr                       #UnaryOperator
@@ -47,10 +50,17 @@ method_call: IDENT DOT IDENT OPEN_PARENTHESIS arg_list? CLOSE_PARENTHESIS  #Meth
 type: data_structure_type                                            #DataStructureType
     | primitive_type                                                 #PrimitiveType;
 
-data_structure_type: STACK LT primitive_type GT                      #StackType;
+data_structure_type: STACK LT primitive_type GT                          #StackType
+    | ARRAY LT primitive_type GT OPEN_PARENTHESIS arg_list CLOSE_PARENTHESIS
+     array_initialiser?                                                  #ArrayType
+    ;
 
 primitive_type: NUMBER_TYPE                                          #NumberType
     | BOOL_TYPE                                                      #BoolType
     ;
 
 bool: TRUE | FALSE;
+
+array_initialiser: OPEN_CURLY_BRACKET expr (COMMA expr)* CLOSE_CURLY_BRACKET;
+
+array_access: IDENT OPEN_SQUARE_BRACKET expr CLOSE_SQUARE_BRACKET;

--- a/antlr_config/ManimParser.g4
+++ b/antlr_config/ManimParser.g4
@@ -25,7 +25,7 @@ stat: SLEEP OPEN_PARENTHESIS expr CLOSE_PARENTHESIS SEMI                 #SleepS
     | RETURN expr? SEMI                                                  #ReturnStatement;
 
 assignment_lhs: IDENT           #IdentifierAssignment
-    | array_access              #ArrayAccessAssignment;
+    | array_elem                #ArrayElemAssignment;
 
 elseIf: ELSE IF OPEN_PARENTHESIS elifCond=expr CLOSE_PARENTHESIS OPEN_CURLY_BRACKET elifStat=stat? CLOSE_CURLY_BRACKET;
 
@@ -34,8 +34,10 @@ arg_list: expr (COMMA expr)*                                        #ArgumentLis
 expr: NUMBER                                                        #NumberLiteral
     | bool                                                          #BooleanLiteral
     | IDENT                                                         #Identifier
-    | array_access                                                  #ArrayAccessExpr
-    | NEW data_structure_type                                       #DataStructureContructor
+    | array_elem                                                    #ArrayElemExpr
+    | NEW data_structure_type
+    OPEN_PARENTHESIS arg_list? CLOSE_PARENTHESIS
+    data_structure_initialiser?                                     #DataStructureContructor
     | method_call                                                   #MethodCallExpression
     | unary_operator=(ADD | MINUS | NOT) expr                       #UnaryOperator
     | left=expr binary_operator=(ADD | MINUS | TIMES) right=expr    #BinaryExpression
@@ -50,9 +52,8 @@ method_call: IDENT DOT IDENT OPEN_PARENTHESIS arg_list? CLOSE_PARENTHESIS  #Meth
 type: data_structure_type                                            #DataStructureType
     | primitive_type                                                 #PrimitiveType;
 
-data_structure_type: STACK LT primitive_type GT                          #StackType
-    | ARRAY LT primitive_type GT OPEN_PARENTHESIS arg_list CLOSE_PARENTHESIS
-     array_initialiser?                                                  #ArrayType
+data_structure_type: STACK LT primitive_type GT                      #StackType
+    | ARRAY LT primitive_type GT                                     #ArrayType
     ;
 
 primitive_type: NUMBER_TYPE                                          #NumberType
@@ -61,6 +62,6 @@ primitive_type: NUMBER_TYPE                                          #NumberType
 
 bool: TRUE | FALSE;
 
-array_initialiser: OPEN_CURLY_BRACKET expr (COMMA expr)* CLOSE_CURLY_BRACKET;
+data_structure_initialiser: OPEN_CURLY_BRACKET expr (COMMA expr)* CLOSE_CURLY_BRACKET;
 
-array_access: IDENT OPEN_SQUARE_BRACKET expr CLOSE_SQUARE_BRACKET;
+array_elem: IDENT OPEN_SQUARE_BRACKET expr CLOSE_SQUARE_BRACKET;

--- a/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
+++ b/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
@@ -74,9 +74,18 @@ fun unsupportedMethodError(dataStructureType: String, method: String, ctx: Parse
     addSemanticError("$dataStructureType does not support $method method", getErrorLinePos(ctx))
 }
 
-fun numOfArgsInMethodCallError(dataStructureType: String, method: String, numArgs: Int, ctx: ParserRuleContext) {
+fun numOfArgsInMethodCallError(
+    dataStructureType: String,
+    method: String,
+    numArgs: Int,
+    expected: Int,
+    ctx: ParserRuleContext
+) {
     // To modify once nex version is merged
-    addSemanticError("$method method on $dataStructureType does not accept $numArgs arguments", getErrorLinePos(ctx))
+    addSemanticError(
+        "$method method on $dataStructureType does not accept $numArgs arguments, expects $expected",
+        getErrorLinePos(ctx)
+    )
 }
 
 fun typeOfArgsInMethodCallError(

--- a/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
+++ b/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
@@ -14,6 +14,16 @@ fun declareAssignError(
     )
 }
 
+fun inconsistentTypeError(
+    expected: Type,
+    ctx: ParserRuleContext
+) {
+    addSemanticError(
+        "All elements must be of type $expected",
+        getErrorLinePos(ctx)
+    )
+}
+
 fun redeclarationError(
     variable: String, variableType: Type,
     ctx: ParserRuleContext

--- a/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
+++ b/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
@@ -20,7 +20,7 @@ fun inconsistentTypeError(
     ctx: ParserRuleContext
 ) {
     addSemanticError(
-        "All elements must be of type $expected",
+        "All values must be of type $expected",
         getErrorLinePos(ctx)
     )
 }

--- a/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
+++ b/src/main/kotlin/com/manimdsl/errorhandling/semanticerror/SemanticErrorHandling.kt
@@ -1,6 +1,7 @@
 package com.manimdsl.errorhandling.semanticerror
 
 import com.manimdsl.errorhandling.ErrorHandler.addSemanticError
+import com.manimdsl.frontend.DataStructureType
 import com.manimdsl.frontend.Type
 import org.antlr.v4.runtime.ParserRuleContext
 
@@ -23,6 +24,19 @@ fun inconsistentTypeError(
         getErrorLinePos(ctx)
     )
 }
+
+fun missingConstructorArgumentsError(
+    dataStructureType: DataStructureType,
+    expected: Int,
+    actual: Int,
+    ctx: ParserRuleContext
+) {
+    addSemanticError(
+        "$dataStructureType constructor expects $expected arguments but only found $actual",
+        getErrorLinePos(ctx)
+    )
+}
+
 
 fun redeclarationError(
     variable: String, variableType: Type,

--- a/src/main/kotlin/com/manimdsl/frontend/AbstractSyntaxTree.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/AbstractSyntaxTree.kt
@@ -91,7 +91,7 @@ data class ElseNode(
 // Expressions
 sealed class ExpressionNode(override val lineNumber: Int) : CodeNode(lineNumber)
 data class IdentifierNode(override val lineNumber: Int, val identifier: String) : ExpressionNode(lineNumber)
-data class ArrayAccessNode(override val lineNumber: Int, val arrayIdentifier: String, val index: ExpressionNode) :
+data class ArrayElemNode(override val lineNumber: Int, val arrayIdentifier: String, val index: ExpressionNode) :
     ExpressionNode(lineNumber)
 
 data class NumberNode(override val lineNumber: Int, val double: Double) : ExpressionNode(lineNumber)
@@ -107,8 +107,13 @@ data class MethodCallNode(
 data class ConstructorNode(
     override val lineNumber: Int,
     val type: DataStructureType,
-    val arguments: List<ExpressionNode>
+    val arguments: List<ExpressionNode>,
+    val initialValue: List<ExpressionNode>
 ) : ExpressionNode(lineNumber)
+
+data class DataStructureInitialiserNode(
+    val expressions: List<ExpressionNode>
+) : ASTNode()
 
 data class FunctionCallNode(
     override val lineNumber: Int,

--- a/src/main/kotlin/com/manimdsl/frontend/AbstractSyntaxTree.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/AbstractSyntaxTree.kt
@@ -91,6 +91,9 @@ data class ElseNode(
 // Expressions
 sealed class ExpressionNode(override val lineNumber: Int) : CodeNode(lineNumber)
 data class IdentifierNode(override val lineNumber: Int, val identifier: String) : ExpressionNode(lineNumber)
+data class ArrayAccessNode(override val lineNumber: Int, val arrayIdentifier: String, val index: ExpressionNode) :
+    ExpressionNode(lineNumber)
+
 data class NumberNode(override val lineNumber: Int, val double: Double) : ExpressionNode(lineNumber)
 data class BoolNode(override val lineNumber: Int, val value: Boolean) : ExpressionNode(lineNumber)
 data class VoidNode(override val lineNumber: Int) : ExpressionNode(lineNumber)

--- a/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
@@ -175,8 +175,8 @@ class ManimParserVisitor : ManimParserBaseVisitor<ASTNode>() {
     }
 
     override fun visitArrayElemAssignment(ctx: ArrayElemAssignmentContext): Type {
-        val arrayAccessNode = visit(ctx.array_elem()) as ArrayElemNode
-        val arrayType = symbolTable.getTypeOf(arrayAccessNode.arrayIdentifier)
+        val arrayElem = visit(ctx.array_elem()) as ArrayElemNode
+        val arrayType = symbolTable.getTypeOf(arrayElem.arrayIdentifier)
 
         // Return element type
         return if (arrayType is ArrayType) {

--- a/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
@@ -265,8 +265,6 @@ class ManimParserVisitor : ManimParserBaseVisitor<ASTNode>() {
 
         val dataStructureMethod = if (dataStructureType is DataStructureType) {
             val method = dataStructureType.getMethodByName(methodName)
-
-
             // Assume for now we only have one type inside the data structure and data structure functions only deal with this type
             val argTypes = arguments.map { semanticAnalyser.inferType(symbolTable, it) }.toList()
             semanticAnalyser.primitiveArgTypesCheck(argTypes, methodName, dataStructureType, ctx)
@@ -304,7 +302,7 @@ class ManimParserVisitor : ManimParserBaseVisitor<ASTNode>() {
         return functionCallNode
     }
 
-    override fun visitDataStructureContructor(ctx: DataStructureContructorContext): ASTNode {
+    override fun visitDataStructureConstructor(ctx: DataStructureConstructorContext): ASTNode {
         val dataStructureType = visit(ctx.data_structure_type()) as DataStructureType
 
         // Check arguments

--- a/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
@@ -116,7 +116,13 @@ class SemanticAnalysis {
         ctx: ParserRuleContext
     ) {
         if (method != ErrorMethod && method.argumentTypes.size != numArgs) {
-            numOfArgsInMethodCallError(dataStructureType.toString(), method.toString(), numArgs, ctx)
+            numOfArgsInMethodCallError(
+                dataStructureType.toString(),
+                method.toString(),
+                numArgs,
+                method.argumentTypes.size,
+                ctx
+            )
         }
     }
 

--- a/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
@@ -188,7 +188,7 @@ class SemanticAnalysis {
                     dataStructureMethod,
                     ctx.arg_list()
                 )
-                is ManimParser.DataStructureContructorContext -> incompatibleArgumentTypesCheck(
+                is ManimParser.DataStructureConstructorContext -> incompatibleArgumentTypesCheck(
                     dataStructureType,
                     argumentTypes,
                     dataStructureMethod,
@@ -385,7 +385,7 @@ class SemanticAnalysis {
         dataStructureType: DataStructureType,
         initialValue: List<ExpressionNode>,
         argumentTypes: List<Type>,
-        ctx: ManimParser.DataStructureContructorContext
+        ctx: ManimParser.DataStructureConstructorContext
     ) {
         val constructor = dataStructureType.getConstructor()
         if (initialValue.isEmpty() && argumentTypes.size < constructor.minRequiredArgsWithoutInitialValue) {

--- a/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
@@ -101,16 +101,6 @@ class SemanticAnalysis {
 
     fun invalidNumberOfArgumentsCheck(
         dataStructureType: DataStructureType,
-        methodName: String,
-        numArgs: Int,
-        ctx: ParserRuleContext
-    ) {
-        val method = dataStructureType.getMethodByName(methodName)
-        invalidNumberOfArgumentsCheck(dataStructureType, method, numArgs, ctx)
-    }
-
-    fun invalidNumberOfArgumentsCheck(
-        dataStructureType: DataStructureType,
         method: DataStructureMethod,
         numArgs: Int,
         ctx: ParserRuleContext

--- a/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
@@ -17,6 +17,7 @@ class SemanticAnalysis {
             is BoolNode -> BoolType
             is VoidNode -> VoidType
             is FunctionCallNode -> currentSymbolTable.getTypeOf(expression.functionIdentifier)
+            is ArrayAccessNode -> TODO()
         }
 
     private fun getUnaryExpressionType(expression: UnaryExpression, currentSymbolTable: SymbolTableVisitor): Type {

--- a/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
@@ -17,10 +17,10 @@ class SemanticAnalysis {
             is BoolNode -> BoolType
             is VoidNode -> VoidType
             is FunctionCallNode -> currentSymbolTable.getTypeOf(expression.functionIdentifier)
-            is ArrayElemNode -> getArrayAccessType(expression, currentSymbolTable)
+            is ArrayElemNode -> getArrayElemType(expression, currentSymbolTable)
         }
 
-    private fun getArrayAccessType(expression: ArrayElemNode, currentSymbolTable: SymbolTableVisitor): Type {
+    private fun getArrayElemType(expression: ArrayElemNode, currentSymbolTable: SymbolTableVisitor): Type {
         // To extend to multiple dimensions perform below recursively
         val arrayType = currentSymbolTable.getTypeOf(expression.arrayIdentifier)
         return if (arrayType is ArrayType) {

--- a/src/main/kotlin/com/manimdsl/frontend/SymbolTableVisitor.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SymbolTableVisitor.kt
@@ -15,12 +15,6 @@ data class FunctionData(
     override var type: Type,
 ) : SymbolTableData
 
-data class ArrayData(
-    val dimensions: List<Int>,
-    val elementType: Type,
-    override val type: Type
-) : SymbolTableData
-
 /* Visitor for symbol table used when creating and traversing AST */
 class SymbolTableVisitor {
     private val scopes = mutableListOf<SymbolTable>(GlobalScopeSymbolTable())

--- a/src/main/kotlin/com/manimdsl/frontend/SymbolTableVisitor.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SymbolTableVisitor.kt
@@ -9,10 +9,16 @@ open class IdentifierData(override val type: Type) : SymbolTableData
 object ErrorIdentifierData : IdentifierData(ErrorType)
 
 data class FunctionData(
-        val inferred : Boolean,
-        var firstTime: Boolean,
-        val parameters: List<ParameterNode>,
-        override var type: Type,
+    val inferred: Boolean,
+    var firstTime: Boolean,
+    val parameters: List<ParameterNode>,
+    override var type: Type,
+) : SymbolTableData
+
+data class ArrayData(
+    val dimensions: List<Int>,
+    val elementType: Type,
+    override val type: Type
 ) : SymbolTableData
 
 /* Visitor for symbol table used when creating and traversing AST */

--- a/src/main/kotlin/com/manimdsl/frontend/Type.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/Type.kt
@@ -20,11 +20,23 @@ object BoolType : PrimitiveType() {
 
 sealed class DataStructureType(
     open var internalType: Type,
-    open val methods: HashMap<String, DataStructureMethod>
+    open val methods: Map<String, DataStructureMethod>
 ) : Type() {
     abstract fun containsMethod(method: String): Boolean
     abstract fun getMethodByName(method: String): DataStructureMethod
+}
 
+data class ArrayType(
+    override var internalType: Type,
+    override val methods: Map<String, DataStructureMethod> = emptyMap()
+) : DataStructureType(internalType, methods) {
+    override fun containsMethod(method: String): Boolean {
+        return false;
+    }
+
+    override fun getMethodByName(method: String): DataStructureMethod {
+        return ErrorMethod
+    }
 }
 
 
@@ -42,12 +54,16 @@ object ErrorMethod : DataStructureMethod {
 data class ArgumentNode(val arguments: List<ExpressionNode>) : ASTNode()
 data class StackType(
     override var internalType: Type,
-    override val methods: HashMap<String, DataStructureMethod> = hashMapOf(
+    override val methods: Map<String, DataStructureMethod> = hashMapOf(
         "push" to PushMethod(
             argumentTypes = listOf(
                 internalType,
             )
-        ), "pop" to PopMethod(internalType), "isEmpty" to IsEmptyMethod(), "size" to SizeMethod(),  "peek" to PeekMethod(internalType)
+        ),
+        "pop" to PopMethod(internalType),
+        "isEmpty" to IsEmptyMethod(),
+        "size" to SizeMethod(),
+        "peek" to PeekMethod(internalType)
     )
 ) : DataStructureType(internalType, methods) {
 

--- a/src/main/kotlin/com/manimdsl/frontend/Type.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/Type.kt
@@ -52,7 +52,9 @@ data class ArgumentNode(val arguments: List<ExpressionNode>) : ASTNode()
 
 data class ArrayType(
     override var internalType: Type,
-    override val methods: Map<String, DataStructureMethod> = emptyMap()
+    override val methods: Map<String, DataStructureMethod> = hashMapOf(
+        "length" to Length()
+    )
 ) : DataStructureType(internalType, methods) {
     object ArrayConstructor : ConstructorMethod {
         override val minRequiredArgsWithoutInitialValue: Int = 1
@@ -63,12 +65,18 @@ data class ArrayType(
         override fun toString(): String = "constructor"
     }
 
+    data class Length(
+        override val returnType: Type = NumberType,
+        override var argumentTypes: List<Type> = emptyList(),
+        override val varargs: Boolean = false
+    ) : DataStructureMethod
+
     override fun containsMethod(method: String): Boolean {
-        return false;
+        return methods.containsKey(method)
     }
 
     override fun getMethodByName(method: String): DataStructureMethod {
-        return ErrorMethod
+        return methods.getOrDefault(method, ErrorMethod)
     }
 
     override fun getConstructor(): ConstructorMethod {

--- a/src/main/kotlin/com/manimdsl/frontend/Type.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/Type.kt
@@ -24,7 +24,7 @@ sealed class DataStructureType(
 ) : Type() {
     abstract fun containsMethod(method: String): Boolean
     abstract fun getMethodByName(method: String): DataStructureMethod
-    abstract fun getConstructor(): DataStructureMethod
+    abstract fun getConstructor(): ConstructorMethod
 }
 
 
@@ -32,8 +32,12 @@ interface DataStructureMethod {
     val returnType: Type
     val argumentTypes: List<Type>
 
-    // When true last type in argumentTypes will be for a variable number of arguments
+    // When true last type in argumentTypes will be used to as type of varargs
     val varargs: Boolean
+}
+
+interface ConstructorMethod : DataStructureMethod {
+    val minRequiredArgsWithoutInitialValue: Int
 }
 
 object ErrorMethod : DataStructureMethod {
@@ -50,7 +54,8 @@ data class ArrayType(
     override var internalType: Type,
     override val methods: Map<String, DataStructureMethod> = emptyMap()
 ) : DataStructureType(internalType, methods) {
-    object ArrayConstructor : DataStructureMethod {
+    object ArrayConstructor : ConstructorMethod {
+        override val minRequiredArgsWithoutInitialValue: Int = 1
         override val returnType: Type = VoidType
         override val argumentTypes: List<Type> = listOf(NumberType)
         override val varargs: Boolean = true
@@ -66,7 +71,7 @@ data class ArrayType(
         return ErrorMethod
     }
 
-    override fun getConstructor(): DataStructureMethod {
+    override fun getConstructor(): ConstructorMethod {
         return ArrayConstructor
     }
 
@@ -87,7 +92,8 @@ data class StackType(
         "peek" to PeekMethod(internalType)
     )
 ) : DataStructureType(internalType, methods) {
-    object StackConstructor : DataStructureMethod {
+    object StackConstructor : ConstructorMethod {
+        override val minRequiredArgsWithoutInitialValue: Int = 0
         override val returnType: Type = VoidType
         override val argumentTypes: List<Type> = emptyList()
         override val varargs: Boolean = false
@@ -133,7 +139,7 @@ data class StackType(
         return methods.getOrDefault(method, ErrorMethod)
     }
 
-    override fun getConstructor(): DataStructureMethod {
+    override fun getConstructor(): ConstructorMethod {
         return StackConstructor
     }
 

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -166,6 +166,7 @@ class VirtualMachine(
             is ConstructorNode -> executeConstructor(node, identifier)
             is FunctionCallNode -> executeFunctionCall(node)
             is VoidNode -> VoidValue
+            is ArrayAccessNode -> EmptyValue
         }
 
         private fun executeMethodCall(node: MethodCallNode, insideMethodCall: Boolean): ExecValue {
@@ -285,6 +286,10 @@ class VirtualMachine(
                     linearRepresentation.addAll(instructions)
                     stackValue.manimObject = newObject
                     stackValue
+                }
+                is ArrayType -> {
+                    // TODO()
+                    EmptyValue
                 }
             }
         }

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -166,7 +166,7 @@ class VirtualMachine(
             is ConstructorNode -> executeConstructor(node, identifier)
             is FunctionCallNode -> executeFunctionCall(node)
             is VoidNode -> VoidValue
-            is ArrayAccessNode -> EmptyValue
+            is ArrayElemNode -> TODO()
         }
 
         private fun executeMethodCall(node: MethodCallNode, insideMethodCall: Boolean): ExecValue {

--- a/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
@@ -28,7 +28,7 @@ class ASTConstructionTests {
     fun multiLineProgram() {
         val multiLineProgram = "let x: number = 1.5;\n" +
                 "# code comment\n" +
-                "let y: Stack<number> = new Stack<number>;\n"
+                "let y: Stack<number> = Stack<number>();\n"
         val statements = listOf(
             DeclarationNode(1, "x", NumberNode(1, 1.5)),
             DeclarationNode(3, "y", ConstructorNode(3, StackType(NumberType), emptyList(), emptyList()))
@@ -40,7 +40,7 @@ class ASTConstructionTests {
 
     @Test
     fun methodCallProgram() {
-        val methodProgram = "let y: Stack<number> = new Stack<number>;\n" +
+        val methodProgram = "let y: Stack<number> = Stack<number>();\n" +
                 "y.push(1);\n"
         val statements = listOf(
             DeclarationNode(1, "y", ConstructorNode(1, StackType(NumberType), emptyList(), emptyList())),

--- a/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
@@ -31,7 +31,7 @@ class ASTConstructionTests {
                 "let y: Stack<number> = new Stack<number>;\n"
         val statements = listOf(
             DeclarationNode(1, "x", NumberNode(1, 1.5)),
-            DeclarationNode(3, "y", ConstructorNode(3, StackType(NumberType), listOf()))
+            DeclarationNode(3, "y", ConstructorNode(3, StackType(NumberType), emptyList(), emptyList()))
         )
         val reference = ProgramNode(listOf(), statements)
         val actual = buildAST(multiLineProgram)
@@ -43,7 +43,7 @@ class ASTConstructionTests {
         val methodProgram = "let y: Stack<number> = new Stack<number>;\n" +
                 "y.push(1);\n"
         val statements = listOf(
-            DeclarationNode(1, "y", ConstructorNode(1, StackType(NumberType), listOf())),
+            DeclarationNode(1, "y", ConstructorNode(1, StackType(NumberType), emptyList(), emptyList())),
             MethodCallNode(
                 2,
                 "y",

--- a/src/test/kotlin/com/manimdsl/ValidASTTests.kt
+++ b/src/test/kotlin/com/manimdsl/ValidASTTests.kt
@@ -31,7 +31,7 @@ class ValidASTTests {
                 "let y: Stack<number> = new Stack<number>;\n"
         val statements = listOf(
             DeclarationNode(1, "x", NumberNode(1, 1.5)),
-            DeclarationNode(3, "y", ConstructorNode(3, StackType(NumberType), listOf()))
+            DeclarationNode(3, "y", ConstructorNode(3, StackType(NumberType), emptyList(), emptyList()))
         )
         val reference = ProgramNode(listOf(), statements)
 
@@ -44,7 +44,7 @@ class ValidASTTests {
         val methodProgram = "let y: Stack<number> = new Stack<number>;\n" +
                 "y.push(1);\n"
         val statements = listOf(
-            DeclarationNode(1, "y", ConstructorNode(1, StackType(NumberType), listOf())),
+            DeclarationNode(1, "y", ConstructorNode(1, StackType(NumberType), emptyList(), emptyList())),
             MethodCallNode(2, "y", StackType.PushMethod(argumentTypes = listOf(NumberType)), listOf(NumberNode(2, 1.0)))
         )
         val reference = ProgramNode(listOf(), statements)

--- a/src/test/kotlin/com/manimdsl/ValidASTTests.kt
+++ b/src/test/kotlin/com/manimdsl/ValidASTTests.kt
@@ -28,7 +28,7 @@ class ValidASTTests {
     fun multiLineProgram() {
         val multiLineProgram = "let x: number = 1.5;\n" +
                 "# code comment\n" +
-                "let y: Stack<number> = new Stack<number>;\n"
+                "let y: Stack<number> = Stack<number>();\n"
         val statements = listOf(
             DeclarationNode(1, "x", NumberNode(1, 1.5)),
             DeclarationNode(3, "y", ConstructorNode(3, StackType(NumberType), emptyList(), emptyList()))
@@ -41,7 +41,7 @@ class ValidASTTests {
 
     @Test
     fun methodCallProgram() {
-        val methodProgram = "let y: Stack<number> = new Stack<number>;\n" +
+        val methodProgram = "let y: Stack<number> = Stack<number>();\n" +
                 "y.push(1);\n"
         val statements = listOf(
             DeclarationNode(1, "y", ConstructorNode(1, StackType(NumberType), emptyList(), emptyList())),

--- a/src/test/kotlin/com/manimdsl/semanticanalysis/InvalidSemanticTests.kt
+++ b/src/test/kotlin/com/manimdsl/semanticanalysis/InvalidSemanticTests.kt
@@ -260,6 +260,42 @@ class InvalidSemanticTests {
         )
     }
 
+    @Test
+    fun arrayMissingConstructorArguments() {
+        runSyntaxAndSemanticAnalysis("arrayMissingConstructorArguments.manimdsl")
+        assertTrue(
+            outputStreamCaptor.toString()
+                .contains(Regex(".* constructor expects .* arguments but only found .*"))
+        )
+    }
+
+    @Test
+    fun arrayInvalidTypesInInitialiserCheck() {
+        runSyntaxAndSemanticAnalysis("arrayInvalidTypesInInitialiserCheck.manimdsl")
+        assertTrue(
+            outputStreamCaptor.toString()
+                .contains(Regex("All values must be of type .*"))
+        )
+    }
+
+    @Test
+    fun arrayInvalidTypesInConstructorCheck() {
+        runSyntaxAndSemanticAnalysis("arrayInvalidTypesInConstructorCheck.manimdsl")
+        assertTrue(
+            outputStreamCaptor.toString()
+                .contains(Regex("constructor method on .* does not accept argument .* of type .*"))
+        )
+    }
+
+    @Test
+    fun arrayAccessIncorrectIndexType() {
+        runSyntaxAndSemanticAnalysis("arrayAccessIncorrectIndexType.manimdsl")
+        assertTrue(
+            outputStreamCaptor.toString()
+                .contains(Regex("Expected expression of type number but found .*"))
+        )
+    }
+
 
     private fun runSyntaxAndSemanticAnalysis(fileName: String) {
         val inputFile = File("$semanticErrorFilePath/$fileName")

--- a/src/test/kotlin/com/manimdsl/semanticanalysis/InvalidSemanticTests.kt
+++ b/src/test/kotlin/com/manimdsl/semanticanalysis/InvalidSemanticTests.kt
@@ -296,6 +296,15 @@ class InvalidSemanticTests {
         )
     }
 
+    @Test
+    fun stackTooManyArgumentsInConstructor() {
+        runSyntaxAndSemanticAnalysis("stackTooManyArgumentsInConstructor.manimdsl")
+        assertTrue(
+            outputStreamCaptor.toString()
+                .contains(Regex("constructor method on Stack<.*> does not accept .* arguments, expects 0"))
+        )
+    }
+
 
     private fun runSyntaxAndSemanticAnalysis(fileName: String) {
         val inputFile = File("$semanticErrorFilePath/$fileName")

--- a/src/test/testFiles/invalid/runtimeErrors/popEmptyStack.manimdsl
+++ b/src/test/testFiles/invalid/runtimeErrors/popEmptyStack.manimdsl
@@ -1,2 +1,2 @@
-let stack1 = new Stack<number>;
+let stack1 = Stack<number>();
 let x = stack1.pop();

--- a/src/test/testFiles/invalid/runtimeErrors/popEmptyStackInFunction.manimdsl
+++ b/src/test/testFiles/invalid/runtimeErrors/popEmptyStackInFunction.manimdsl
@@ -1,5 +1,5 @@
 fun function(x: number): Stack<number> {
-    let stack1 = new Stack<number>;
+    let stack1 = Stack<number>();
     let y = stack1.pop();
     return stack1;
 }

--- a/src/test/testFiles/invalid/runtimeErrors/popEmptyStackInFunctionMultipleCallsDown.manimdsl
+++ b/src/test/testFiles/invalid/runtimeErrors/popEmptyStackInFunctionMultipleCallsDown.manimdsl
@@ -3,7 +3,7 @@ fun function(st: Stack<number>): Stack<number> {
     function(st);
     return st;
 }
-Stack<number> st = new Stack<number>;
+Stack<number> st = Stack<number>();
 st.push(2);
 st.push(3);
 let stack2 = function(st);

--- a/src/test/testFiles/invalid/runtimeErrors/popEmptyStackInsideIf.manimdsl
+++ b/src/test/testFiles/invalid/runtimeErrors/popEmptyStackInsideIf.manimdsl
@@ -1,4 +1,4 @@
 if (true) {
-    let stack1 = new Stack<number>;
+    let stack1 = Stack<number>();
     let x = stack1.pop();
 }

--- a/src/test/testFiles/invalid/runtimeErrors/popEmptyStackNoAssignment.manimdsl
+++ b/src/test/testFiles/invalid/runtimeErrors/popEmptyStackNoAssignment.manimdsl
@@ -2,5 +2,5 @@ fun function(x: number, st: Stack<number>): Stack<number> {
     st.pop();
     return st;
 }
-Stack<number> st = new Stack<number>;
+Stack<number> st = Stack<number>();
 let stack2 = function(4, st);

--- a/src/test/testFiles/invalid/semanticErrors/arrayAccessIncorrectIndexType.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayAccessIncorrectIndexType.manimdsl
@@ -1,0 +1,3 @@
+let x = new Array<number>(3);
+
+let y = x[false];

--- a/src/test/testFiles/invalid/semanticErrors/arrayAccessIncorrectIndexType.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayAccessIncorrectIndexType.manimdsl
@@ -1,3 +1,3 @@
-let x = new Array<number>(3);
+let x = Array<number>(3);
 
 let y = x[false];

--- a/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInConstructorCheck.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInConstructorCheck.manimdsl
@@ -1,0 +1,1 @@
+let x = new Array<number>(false);

--- a/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInConstructorCheck.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInConstructorCheck.manimdsl
@@ -1,1 +1,1 @@
-let x = new Array<number>(false);
+let x = Array<number>(false);

--- a/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInInitialiserCheck.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInInitialiserCheck.manimdsl
@@ -1,0 +1,1 @@
+let x = new Array<number>(){true, false, true}

--- a/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInInitialiserCheck.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayInvalidTypesInInitialiserCheck.manimdsl
@@ -1,1 +1,1 @@
-let x = new Array<number>(){true, false, true}
+let x = Array<number>(){true, false, true}

--- a/src/test/testFiles/invalid/semanticErrors/arrayMissingConstructorArguments.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayMissingConstructorArguments.manimdsl
@@ -1,1 +1,1 @@
-let x = new Array<number>();
+let x = Array<number>();

--- a/src/test/testFiles/invalid/semanticErrors/arrayMissingConstructorArguments.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/arrayMissingConstructorArguments.manimdsl
@@ -1,0 +1,1 @@
+let x = new Array<number>();

--- a/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns.manimdsl
@@ -6,5 +6,5 @@ fun get(x: number, stack: Stack<number>): number {
     }
 }
 
-let stack = new Stack<number>();
+let stack = Stack<number>();
 get(4, stack);

--- a/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns.manimdsl
@@ -6,5 +6,5 @@ fun get(x: number, stack: Stack<number>): number {
     }
 }
 
-let stack = new Stack<number>;
+let stack = new Stack<number>();
 get(4, stack);

--- a/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns2.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns2.manimdsl
@@ -7,5 +7,5 @@ fun get(x: number, stack: Stack<number>): number {
     }
 }
 
-let stack = new Stack<number>;
+let stack = new Stack<number>();
 get(4, stack);

--- a/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns2.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/ifStatementsBranchesMustAllHaveReturns2.manimdsl
@@ -7,5 +7,5 @@ fun get(x: number, stack: Stack<number>): number {
     }
 }
 
-let stack = new Stack<number>();
+let stack = Stack<number>();
 get(4, stack);

--- a/src/test/testFiles/invalid/semanticErrors/incompatibleExplicitCast.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incompatibleExplicitCast.manimdsl
@@ -1,1 +1,1 @@
-let x: number = new Stack<number>;
+let x: number = new Stack<number>();

--- a/src/test/testFiles/invalid/semanticErrors/incompatibleExplicitCast.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incompatibleExplicitCast.manimdsl
@@ -1,1 +1,1 @@
-let x: number = new Stack<number>();
+let x: number = Stack<number>();

--- a/src/test/testFiles/invalid/semanticErrors/incompatibleTypesAssignment.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incompatibleTypesAssignment.manimdsl
@@ -1,2 +1,2 @@
 let x: number = 2;
-x = new Stack<number>;
+x = new Stack<number>();

--- a/src/test/testFiles/invalid/semanticErrors/incompatibleTypesAssignment.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incompatibleTypesAssignment.manimdsl
@@ -1,2 +1,2 @@
 let x: number = 2;
-x = new Stack<number>();
+x = Stack<number>();

--- a/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForFunctionCall.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForFunctionCall.manimdsl
@@ -2,5 +2,5 @@ fun function(x: number): number {
     let z: number = x*2;
     return z;
 }
-let x = new Stack<number>();
+let x = Stack<number>();
 let z = function(x);

--- a/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForFunctionCall.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForFunctionCall.manimdsl
@@ -2,5 +2,5 @@ fun function(x: number): number {
     let z: number = x*2;
     return z;
 }
-let x = new Stack<number>;
+let x = new Stack<number>();
 let z = function(x);

--- a/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForPush.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForPush.manimdsl
@@ -1,3 +1,3 @@
-let x = new Stack<number>;
-let y = new Stack<number>;
+let x = new Stack<number>();
+let y = new Stack<number>();
 x.push(y);

--- a/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForPush.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incorrectArgTypeForPush.manimdsl
@@ -1,3 +1,3 @@
-let x = new Stack<number>();
-let y = new Stack<number>();
+let x = Stack<number>();
+let y = Stack<number>();
 x.push(y);

--- a/src/test/testFiles/invalid/semanticErrors/incorrectMethodName.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incorrectMethodName.manimdsl
@@ -1,2 +1,2 @@
-let x = new Stack<number>();
+let x = Stack<number>();
 x.hello(5);

--- a/src/test/testFiles/invalid/semanticErrors/incorrectMethodName.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/incorrectMethodName.manimdsl
@@ -1,2 +1,2 @@
-let x = new Stack<number>;
+let x = new Stack<number>();
 x.hello(5);

--- a/src/test/testFiles/invalid/semanticErrors/pushWithTwoArgs.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/pushWithTwoArgs.manimdsl
@@ -1,2 +1,2 @@
-let x = new Stack<number>;
+let x = new Stack<number>();
 x.push(1, 2);

--- a/src/test/testFiles/invalid/semanticErrors/pushWithTwoArgs.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/pushWithTwoArgs.manimdsl
@@ -1,2 +1,2 @@
-let x = new Stack<number>();
+let x = Stack<number>();
 x.push(1, 2);

--- a/src/test/testFiles/invalid/semanticErrors/stackTooManyArgumentsInConstructor.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/stackTooManyArgumentsInConstructor.manimdsl
@@ -1,0 +1,1 @@
+let x = new Stack<number>(1);

--- a/src/test/testFiles/invalid/semanticErrors/stackTooManyArgumentsInConstructor.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/stackTooManyArgumentsInConstructor.manimdsl
@@ -1,1 +1,1 @@
-let x = new Stack<number>(1);
+let x = Stack<number>(1);

--- a/src/test/testFiles/invalid/semanticErrors/undeclaredFunctionForwardDeclaration.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/undeclaredFunctionForwardDeclaration.manimdsl
@@ -1,5 +1,5 @@
 fun func1(x: number) {
-    let y: Stack<number> = new Stack<number>();
+    let y: Stack<number> = Stack<number>();
     y = func2(5);
 
 }

--- a/src/test/testFiles/invalid/semanticErrors/undeclaredFunctionForwardDeclaration.manimdsl
+++ b/src/test/testFiles/invalid/semanticErrors/undeclaredFunctionForwardDeclaration.manimdsl
@@ -1,5 +1,5 @@
 fun func1(x: number) {
-    let y: Stack<number> = new Stack<number>;
+    let y: Stack<number> = new Stack<number>();
     y = func2(5);
 
 }

--- a/src/test/testFiles/invalid/syntaxErrors/invalidTypeParameter.manimdsl
+++ b/src/test/testFiles/invalid/syntaxErrors/invalidTypeParameter.manimdsl
@@ -1,1 +1,1 @@
-let a: Stack = new Stack<asd>;
+let a: Stack = Stack<asd>();

--- a/src/test/testFiles/invalid/syntaxErrors/mismatchedInput.manimdsl
+++ b/src/test/testFiles/invalid/syntaxErrors/mismatchedInput.manimdsl
@@ -1,1 +1,1 @@
-let x: Stack = new Weird;
+let x: Stack = Weird();

--- a/src/test/testFiles/invalid/syntaxErrors/missingTypeParameter.manimdsl
+++ b/src/test/testFiles/invalid/syntaxErrors/missingTypeParameter.manimdsl
@@ -1,1 +1,1 @@
-let a = new Stack;
+let a = Stack<>();

--- a/src/test/testFiles/valid/arrays.manimdsl
+++ b/src/test/testFiles/valid/arrays.manimdsl
@@ -1,0 +1,4 @@
+let a = new Array<number>(3);
+let b = new Array<number>(3){1,2,3};
+let c = new Array<number>(){1,2,3};
+

--- a/src/test/testFiles/valid/arrays.manimdsl
+++ b/src/test/testFiles/valid/arrays.manimdsl
@@ -2,3 +2,4 @@ let a = new Array<number>(3);
 let b = new Array<number>(3){1,2,3};
 let c = new Array<number>(){1,2,3};
 
+let y = c.length();

--- a/src/test/testFiles/valid/arrays.manimdsl
+++ b/src/test/testFiles/valid/arrays.manimdsl
@@ -1,5 +1,5 @@
-let a = new Array<number>(3);
-let b = new Array<number>(3){1,2,3};
-let c = new Array<number>(){1,2,3};
+let a = Array<number>(3);
+let b = Array<number>(3){1,2,3};
+let c = Array<number>(){1,2,3};
 
 let y = c.length();

--- a/src/test/testFiles/valid/example.manimdsl
+++ b/src/test/testFiles/valid/example.manimdsl
@@ -1,4 +1,4 @@
 let x = 1;
-let y: Stack<number> = new Stack<number>();
+let y: Stack<number> = Stack<number>();
 y.push(x);
 let z = y.pop();

--- a/src/test/testFiles/valid/example.manimdsl
+++ b/src/test/testFiles/valid/example.manimdsl
@@ -1,4 +1,4 @@
 let x = 1;
-let y: Stack<number> = new Stack<number>;
+let y: Stack<number> = new Stack<number>();
 y.push(x);
 let z = y.pop();

--- a/src/test/testFiles/valid/popEmptyStackNeverExecutedAtRuntime.manimdsl
+++ b/src/test/testFiles/valid/popEmptyStackNeverExecutedAtRuntime.manimdsl
@@ -1,5 +1,5 @@
 if (false) {
-    let y = new Stack<number>;
+    let y = new Stack<number>();
     let x = y.pop();
 } else {
     let x = 0;

--- a/src/test/testFiles/valid/popEmptyStackNeverExecutedAtRuntime.manimdsl
+++ b/src/test/testFiles/valid/popEmptyStackNeverExecutedAtRuntime.manimdsl
@@ -1,5 +1,5 @@
 if (false) {
-    let y = new Stack<number>();
+    let y = Stack<number>();
     let x = y.pop();
 } else {
     let x = 0;

--- a/src/test/testFiles/valid/stackConstructor.manimdsl
+++ b/src/test/testFiles/valid/stackConstructor.manimdsl
@@ -1,2 +1,2 @@
-let x = new Stack<number>() {1, 2, 3};
-let y = new Stack<number>();
+let x = Stack<number>() {1, 2, 3};
+let y = Stack<number>();

--- a/src/test/testFiles/valid/stackConstructor.manimdsl
+++ b/src/test/testFiles/valid/stackConstructor.manimdsl
@@ -1,0 +1,2 @@
+let x = new Stack<number>() {1, 2, 3};
+let y = new Stack<number>();

--- a/src/test/testFiles/valid/stackFunction.manimdsl
+++ b/src/test/testFiles/valid/stackFunction.manimdsl
@@ -1,5 +1,5 @@
 fun function(x: number): Stack<number> {
-    let stack1 = new Stack<number>;
+    let stack1 = new Stack<number>();
     stack1.push(x);
     return stack1;
 }

--- a/src/test/testFiles/valid/stackFunction.manimdsl
+++ b/src/test/testFiles/valid/stackFunction.manimdsl
@@ -1,5 +1,5 @@
 fun function(x: number): Stack<number> {
-    let stack1 = new Stack<number>();
+    let stack1 = Stack<number>();
     stack1.push(x);
     return stack1;
 }


### PR DESCRIPTION
### Clubhouse Ticket
[ch137](https://app.clubhouse.io/manim-dsl/story/137/implement-array-on-compiler-frontend)

### Description

Implemented support for arrays on compiler fronted. Added semantic checks and tests to verify correctness. Runtime errors will need to be carried out on backend as expressions are relied on heavily so only upon evaluation can we determine whether accesses are valid, instantiations are the correct dimensions, etc. I have also modified the Stack type to have a constructor also albeit an empty one e.g. `new Stack<number>() {1, 2, 3}` etc.

Added the concept of varargs so example for multidimensional array or methods with variable arguments it will check the last type in the method required types and compare that to argument types passed in when their index exceeds the method required types length.

Fixes # (issue) 

### Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

### How Has This Been Tested?

Added tests to check constructor and type checking for arrays.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules