### PR TITLE
Allocated stack frames depends on remaining allocated memory instead …

### DIFF
--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -25,7 +25,7 @@ class VirtualMachine(
     private val displayLine: MutableList<Int> = mutableListOf()
     private val displayCode: MutableList<String> = mutableListOf()
     private val acceptableNonStatements = setOf("}", "{", "")
-    private val ALLOCATED_STACKS = 1000
+    private val ALLOCATED_STACKS = Runtime.getRuntime().freeMemory()/1000000
 
     init {
         fileLines.indices.forEach {


### PR DESCRIPTION

### Clubhouse Ticket
[ch189](https://app.clubhouse.io/manim-dsl/story/189/runtime-error)

### Description
Just made runtime errors depend on allocated memory

Fixes # (issue) 

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue) :bug

### How Has This Been Tested?

Existing runtime error tests.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules