### PR TITLE
Fixed pointer showing when starting the animation at the origin

### DIFF
--- a/src/main/resources/python/util.py
+++ b/src/main/resources/python/util.py
@@ -16,12 +16,14 @@ def move_arrow_to_line(self, line_number, pointer, code_block, code_text):
         idx += len(code_block.code[i])
 
     if idx > self.code_end:
-        self.play(FadeOut(pointer), runtime=0.1)
+        if pointer in self.mobjects:
+            self.play(FadeOut(pointer), runtime=0.1)
         # [["test, test1"], ["test2", "test3"]]
         self.scroll_down(code_text, (idx - self.code_end))
         # code_text.move_to(code_frame)
     elif idx - 1 < self.code_start:
-        self.play(FadeOut(pointer), runtime=0.1)
+        if pointer in self.mobjects:
+            self.play(FadeOut(pointer), runtime=0.1)
         self.scroll_up(code_text, (self.code_start - idx+len(code_block.code[line_number-1])))
 
     line_object = code_block.get_line_at(line_number)

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -45,12 +45,14 @@ class Main(Scene):
         for i in range(line_number):
             idx += len(code_block.code[i])
         if idx > self.code_end:
-            self.play(FadeOut(pointer), runtime=0.1)
+            if pointer in self.mobjects:
+                self.play(FadeOut(pointer), runtime=0.1)
             # [["test, test1"], ["test2", "test3"]]
             self.scroll_down(code_text, (idx - self.code_end))
             # code_text.move_to(code_frame)
         elif idx - 1 < self.code_start:
-            self.play(FadeOut(pointer), runtime=0.1)
+            if pointer in self.mobjects:
+                self.play(FadeOut(pointer), runtime=0.1)
             self.scroll_up(code_text, (self.code_start - idx+len(code_block.code[line_number-1])))
         line_object = code_block.get_line_at(line_number)
         self.play(FadeIn(pointer.next_to(line_object, LEFT, MED_SMALL_BUFF)))


### PR DESCRIPTION
### Clubhouse Ticket
[ch202](https://app.clubhouse.io/manim-dsl/story/202/fix-pointer-at-start-of-animation)

### Description

Make the pointer start at the line instead of origin at the beginning of the video

Fixes # (issue) 

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue) :bug

### How Has This Been Tested?

Please describe tests added as well.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules