### PR TITLE
Extend style sheet with animation options

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,6 +12,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install Manim
+        run: |
+          python -m pip install --upgrade pip
+          pip install manimlib
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,8 +18,10 @@ jobs:
           python-version: '3.x'
       - name: Install Manim
         run: |
-          python -m pip install --upgrade pip
-          pip install manimlib
+          apt-get update && apt-get install -y texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa
+          apt-get update && apt-get install -y python3 python3-pip sox ffmpeg libcairo2 libcairo2-dev
+          pip3 install --upgrade pip
+          pip3 install manimlib
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,16 +12,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install Manim
-        run: |
-          apt-get update && apt-get install -y texlive texlive-latex-extra texlive-fonts-extra texlive-latex-recommended texlive-science texlive-fonts-extra tipa
-          apt-get update && apt-get install -y python3 python3-pip sox ffmpeg libcairo2 libcairo2-dev
-          pip3 install --upgrade pip
-          pip3 install manimlib
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/src/main/kotlin/com/manimdsl/errorhandling/warnings/WarningHandling.kt
+++ b/src/main/kotlin/com/manimdsl/errorhandling/warnings/WarningHandling.kt
@@ -17,17 +17,3 @@ fun invalidStyleAttribute(attribute: String, expecting: Collection<String>, inva
         }"
     )
 }
-
-fun animationStyleDoesNotAcceptColorWarning(
-    animationStyle: String,
-    validAnimationStylesWithColour: Collection<String>
-) {
-    addWarning(
-        "$animationStyle does not accept color. For color change, please choose one of: ${validAnimationStylesWithColour.joinToString(
-            "', '",
-            prefix = "'",
-            postfix = "'"
-        )
-        }"
-    )
-}

--- a/src/main/kotlin/com/manimdsl/errorhandling/warnings/WarningHandling.kt
+++ b/src/main/kotlin/com/manimdsl/errorhandling/warnings/WarningHandling.kt
@@ -9,11 +9,25 @@ fun undeclaredVariableStyleWarning(identifier: String) {
 fun invalidStyleAttribute(attribute: String, expecting: Collection<String>, invalid: String) {
     addWarning(
         "Invalid value: '$invalid' for attribute '$attribute' expecting: ${
-            expecting.joinToString(
-                "', '",
-                prefix = "'",
-                postfix = "'"
-            )
+        expecting.joinToString(
+            "', '",
+            prefix = "'",
+            postfix = "'"
+        )
+        }"
+    )
+}
+
+fun animationStyleDoesNotAcceptColorWarning(
+    animationStyle: String,
+    validAnimationStylesWithColour: Collection<String>
+) {
+    addWarning(
+        "$animationStyle does not accept color. For color change, please choose one of: ${validAnimationStylesWithColour.joinToString(
+            "', '",
+            prefix = "'",
+            postfix = "'"
+        )
         }"
     )
 }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -22,10 +22,16 @@ data class Sleep(val length: Double = 1.0) : ManimInstr {
     }
 }
 
-data class MoveToLine(val lineNumber: Int, val pointerName: String, val codeBlockName: String, val codeTextVariable: String) : ManimInstr {
+data class MoveToLine(
+    val lineNumber: Int,
+    val pointerName: String,
+    val codeBlockName: String,
+    val codeTextVariable: String
+) : ManimInstr {
     override fun toPython(): List<String> {
         return listOf(
-                "self.move_arrow_to_line($lineNumber, $pointerName, $codeBlockName, $codeTextVariable)")
+            "self.move_arrow_to_line($lineNumber, $pointerName, $codeBlockName, $codeTextVariable)"
+        )
     }
 }
 
@@ -76,7 +82,12 @@ data class StackPopObject(
     }
 }
 
-data class ArrayElemAssignObject(val arrayIdent: String, val index: Int, val newElemValue: ExecValue, val animatedStyle: AnimationProperties?) : ManimInstr {
+data class ArrayElemAssignObject(
+    val arrayIdent: String,
+    val index: Int,
+    val newElemValue: ExecValue,
+    val animatedStyle: AnimationProperties?
+) : ManimInstr {
     override fun toPython(): List<String> {
         val animationString = if (animatedStyle?.textColor != null) ", color=${animatedStyle.textColor}" else ""
         return listOf("self.play($arrayIdent.array_elements[$index].replace_text(\"${newElemValue.value}\"$animationString))")
@@ -89,29 +100,50 @@ data class ArrayShortSwap(val arrayIdent: String, val indices: Pair<Int, Int>) :
     }
 }
 
-data class ArrayLongSwap(val arrayIdent: String, val indices: Pair<Int, Int>, val elem1: String, val elem2: String, val animations: String) : ManimInstr {
+data class ArrayLongSwap(
+    val arrayIdent: String,
+    val indices: Pair<Int, Int>,
+    val elem1: String,
+    val elem2: String,
+    val animations: String
+) : ManimInstr {
     override fun toPython(): List<String> {
-        return listOf("$elem1, $elem2, $animations = $arrayIdent.clone_and_swap(${indices.first}, ${indices.second})",
-                "[self.play(*animation) for animation in $animations]",
-                "$arrayIdent.array_elements[${indices.first}].text = $elem2",
-                "$arrayIdent.array_elements[${indices.second}].text = $elem1")
+        return listOf(
+            "$elem1, $elem2, $animations = $arrayIdent.clone_and_swap(${indices.first}, ${indices.second})",
+            "[self.play(*animation) for animation in $animations]",
+            "$arrayIdent.array_elements[${indices.first}].text = $elem2",
+            "$arrayIdent.array_elements[${indices.second}].text = $elem1"
+        )
     }
 }
 
-data class ArrayElemRestyle(val arrayIdent: String, val indices: List<Int>, val styleProperties: StylesheetProperty, val pointer: Boolean?=false) : ManimInstr {
+data class ArrayElemRestyle(
+    val arrayIdent: String,
+    val indices: List<Int>,
+    val styleProperties: StylesheetProperty,
+    val pointer: Boolean? = false,
+    val animationString: String? = null
+) : ManimInstr {
     override fun toPython(): List<String> {
         val instructions = mutableListOf<String>()
+        val animationString = animationString ?: "FadeToColor"
 
         styleProperties.borderColor?.let {
             for (i in indices) {
-                instructions.add("FadeToColor($arrayIdent.array_elements[$i].shape, ${styleProperties.handleColourValue(it)})")
+                instructions.add(
+                    "FadeToColor($arrayIdent.array_elements[$i].shape, ${styleProperties.handleColourValue(
+                        it
+                    )})"
+                )
 
             }
         }
         for (i in indices) {
             if (pointer == null || pointer) {
-                instructions.add("FadeIn($arrayIdent.array_elements[$i].pointer.next_to($arrayIdent.array_elements[$i].shape, TOP, 0.01)." +
-                        "set_color(${styleProperties.handleColourValue(styleProperties.borderColor ?: "WHITE")}))")
+                instructions.add(
+                    "FadeIn($arrayIdent.array_elements[$i].pointer.next_to($arrayIdent.array_elements[$i].shape, TOP, 0.01)." +
+                            "set_color(${styleProperties.handleColourValue(styleProperties.borderColor ?: "WHITE")}))"
+                )
             } else {
                 instructions.add("self.fade_out_if_needed($arrayIdent.array_elements[$i].pointer)")
             }
@@ -119,8 +151,10 @@ data class ArrayElemRestyle(val arrayIdent: String, val indices: List<Int>, val 
 
         styleProperties.textColor?.let {
             for (i in indices) {
-                instructions.add("FadeToColor($arrayIdent.array_elements[$i].text, " +
-                        "${styleProperties.handleColourValue(it)})")
+                instructions.add(
+                    "$animationString($arrayIdent.array_elements[$i].text, " +
+                            "color=${styleProperties.handleColourValue(it)})"
+                )
             }
         }
 
@@ -144,11 +178,12 @@ data class RestyleObject(
 }
 
 data class UpdateVariableState(
-        val variables: List<String>,
-        val ident: String,
-        val textColor: String? = null) : ManimInstr {
+    val variables: List<String>,
+    val ident: String,
+    val textColor: String? = null
+) : ManimInstr {
     override fun toPython(): List<String> =
-        if(variables.isNotEmpty()) {
+        if (variables.isNotEmpty()) {
             listOf("self.play(*${ident}.update_variable(${variables.map { "\"${it}\"" }}))")
         } else {
             emptyList()

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -58,15 +58,18 @@ data class StackPushObject(
     val shape: Shape,
     val dataStructureIdentifier: String,
     val isPushPop: Boolean = false,
-    val creationStyle: String? = null
+    val creationStyle: String? = null,
+    val runtime: Double? = null
 ) : ManimInstr {
 
     override fun toPython(): List<String> {
         val creationString = if (isPushPop || creationStyle == null) "" else ", creation_style=\"$creationStyle\""
+        val runtimeString = if (runtime != null) ", run_time=$runtime" else ""
+
         val methodName = if (isPushPop) "push_existing" else "push"
 
         return listOf(
-            "[self.play(*animation) for animation in $dataStructureIdentifier.$methodName(${shape.ident}$creationString)]",
+            "[self.play(*animation$runtimeString) for animation in $dataStructureIdentifier.$methodName(${shape.ident}$creationString)]",
             "$dataStructureIdentifier.add($shape)"
         )
     }
@@ -75,12 +78,14 @@ data class StackPushObject(
 data class StackPopObject(
     val shape: Shape,
     val dataStructureIdentifier: String,
-    val insideMethodCall: Boolean
+    val insideMethodCall: Boolean,
+    val runtime: Double? = null
 ) : ManimInstr {
 
     override fun toPython(): List<String> {
+        val runtimeString = if (runtime != null) ", run_time=$runtime" else ""
         return listOf(
-            "[self.play(*animation) for animation in $dataStructureIdentifier.pop(${shape.ident}, fade_out=${(!insideMethodCall).toString()
+            "[self.play(*animation$runtimeString) for animation in $dataStructureIdentifier.pop(${shape.ident}, fade_out=${(!insideMethodCall).toString()
                 .capitalize()})]"
         )
     }
@@ -187,10 +192,11 @@ data class ArrayElemRestyle(
 data class RestyleObject(
     val shape: Shape,
     val newStyle: StylesheetProperty,
+    val runtime: Double?
 ) : ManimInstr {
     override fun toPython(): List<String> {
         return if (shape is StyleableShape) {
-            shape.restyle(newStyle)
+            shape.restyle(newStyle, runtime)
         } else emptyList()
     }
 }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -57,13 +57,16 @@ data class MoveObject(
 data class StackPushObject(
     val shape: Shape,
     val dataStructureIdentifier: String,
-    val isPushPop: Boolean = false
+    val isPushPop: Boolean = false,
+    val creationStyle: String? = null
 ) : ManimInstr {
 
     override fun toPython(): List<String> {
+        val creationString = if (isPushPop || creationStyle == null) "" else ", creation_style=\"$creationStyle\""
         val methodName = if (isPushPop) "push_existing" else "push"
+
         return listOf(
-            "[self.play(*animation) for animation in $dataStructureIdentifier.$methodName(${shape.ident})]",
+            "[self.play(*animation) for animation in $dataStructureIdentifier.$methodName(${shape.ident}$creationString)]",
             "$dataStructureIdentifier.add($shape)"
         )
     }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -126,11 +126,14 @@ data class ArrayElemRestyle(
     val indices: List<Int>,
     val styleProperties: StylesheetProperty,
     val pointer: Boolean? = false,
-    val animationString: String? = null
+    val animationString: String? = null,
+    val runtime: Double? = null
 ) : ManimInstr {
     override fun toPython(): List<String> {
         val instructions = mutableListOf<String>()
         val animationString = animationString ?: "FadeToColor"
+        val runtimeString = if (runtime != null) ", run_time=$runtime" else ""
+
         val animationStringTakesColorAsParameter =
             StyleSheetValidator.validAnimationStrings.getOrDefault(animationString, true)
 
@@ -175,7 +178,7 @@ data class ArrayElemRestyle(
             emptyList()
         } else {
             listOf(
-                "self.play(*[animation for animation in [${instructions.joinToString(", ")}] if animation], run_time=1.5)"
+                "self.play(*[animation for animation in [${instructions.joinToString(", ")}] if animation]$runtimeString)"
             )
         }
     }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -149,7 +149,7 @@ data class InitManimStack(
         val creationString = if (creationStyle != null) ", creation_style=\"$creationStyle\"" else ""
         val python =
             mutableListOf("# Constructing new ${type} \"${text}\"", shape.getConstructor())
-        python.add("self.play($ident.create_init(\"$text\"$creationString))")
+        python.add("self.play(*$ident.create_init(\"$text\"$creationString))")
         return python
     }
 

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -140,6 +140,7 @@ data class InitManimStack(
     val color: String? = null,
     val textColor: String? = null,
     val creationStyle: String? = null,
+    val creationTime: Int? = null,
     private var boundary: List<Pair<Double, Double>> = emptyList(),
     private var maxSize: Int = -1
 ) : DataStructureMObject(type, ident, boundary) {
@@ -147,6 +148,7 @@ data class InitManimStack(
 
     override fun toPython(): List<String> {
         val creationString = if (creationStyle != null) ", creation_style=\"$creationStyle\"" else ""
+        val runtimeString = if (creationTime != null) ", run_time=$creationTime" else ""
         val python =
             mutableListOf("# Constructing new ${type} \"${text}\"", shape.getConstructor())
         python.add("self.play(*$ident.create_init(\"$text\"$creationString))")
@@ -168,6 +170,7 @@ data class ArrayStructure(
     val color: String? = null,
     val textColor: String? = null,
     var creationString: String? = null,
+    val runtime: Double? = null,
     var maxSize: Int = -1,
     private var boundaries: List<Pair<Double, Double>> = emptyList()
 ) : DataStructureMObject(type, ident, boundaries) {
@@ -177,12 +180,14 @@ data class ArrayStructure(
         if (creationString == null) creationString = "FadeIn"
     }
 
+    private val runtimeString = if (runtime != null) ", run_time=$runtime" else ""
+
     override fun toPython(): List<String> {
         return listOf(
             "# Constructing new $type \"$text\"",
             shape.getConstructor(),
             "self.play($creationString($ident.title))",
-            "self.play(*[$creationString(array_elem.all) for array_elem in $ident.array_elements])"
+            "self.play(*[$creationString(array_elem.all$runtimeString) for array_elem in $ident.array_elements])"
         )
     }
 

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -140,7 +140,7 @@ data class InitManimStack(
     val color: String? = null,
     val textColor: String? = null,
     val creationStyle: String? = null,
-    val creationTime: Int? = null,
+    val creationTime: Double? = null,
     private var boundary: List<Pair<Double, Double>> = emptyList(),
     private var maxSize: Int = -1
 ) : DataStructureMObject(type, ident, boundary) {
@@ -151,7 +151,7 @@ data class InitManimStack(
         val runtimeString = if (creationTime != null) ", run_time=$creationTime" else ""
         val python =
             mutableListOf("# Constructing new ${type} \"${text}\"", shape.getConstructor())
-        python.add("self.play(*$ident.create_init(\"$text\"$creationString))")
+        python.add("self.play(*$ident.create_init(\"$text\"$creationString)$runtimeString)")
         return python
     }
 

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -139,15 +139,17 @@ data class InitManimStack(
     val moveToShape: Shape? = null,
     val color: String? = null,
     val textColor: String? = null,
+    val creationStyle: String? = null,
     private var boundary: List<Pair<Double, Double>> = emptyList(),
     private var maxSize: Int = -1
 ) : DataStructureMObject(type, ident, boundary) {
     override var shape: Shape = NullShape
 
     override fun toPython(): List<String> {
+        val creationString = if (creationStyle != null) ", creation_style=\"$creationStyle\"" else ""
         val python =
             mutableListOf("# Constructing new ${type} \"${text}\"", shape.getConstructor())
-        python.add("self.play($ident.create_init(\"$text\"))")
+        python.add("self.play($ident.create_init(\"$text\"$creationString))")
         return python
     }
 

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -166,12 +166,15 @@ data class ArrayStructure(
     val values: Array<ExecValue>,
     val color: String? = null,
     val textColor: String? = null,
-    val creationString: String = "FadeIn",
+    var creationString: String? = null,
     var maxSize: Int = -1,
     private var boundaries: List<Pair<Int, Int>> = emptyList()
 ) : DataStructureMObject(type, ident, boundaries) {
     override var shape: Shape = NullShape
 
+    init {
+        if (creationString == null) creationString = "FadeIn"
+    }
 
     override fun toPython(): List<String> {
         return listOf(

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -152,7 +152,7 @@ data class InitManimStack(
         val runtimeString = if (creationTime != null) ", run_time=$creationTime" else ""
         val python =
             mutableListOf("# Constructing new ${type} \"${text}\"", shape.getConstructor())
-        val newIdent = if (showLabel == null || showLabel) "\"$ident\"" else ""
+        val newIdent = if (showLabel == null || showLabel) "\"$text\"" else ""
         python.add("self.play(*$ident.create_init($newIdent$creationString)$runtimeString)")
         return python
     }

--- a/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/Objects.kt
@@ -166,17 +166,19 @@ data class ArrayStructure(
     val values: Array<ExecValue>,
     val color: String? = null,
     val textColor: String? = null,
+    val creationString: String = "FadeIn",
     var maxSize: Int = -1,
     private var boundaries: List<Pair<Int, Int>> = emptyList()
 ) : DataStructureMObject(type, ident, boundaries) {
     override var shape: Shape = NullShape
 
+
     override fun toPython(): List<String> {
         return listOf(
             "# Constructing new $type \"$text\"",
             shape.getConstructor(),
-            "self.play(ShowCreation($ident.title))",
-            "self.play(*[ShowCreation(array_elem.all) for array_elem in $ident.array_elements])"
+            "self.play($creationString($ident.title))",
+            "self.play(*[$creationString(array_elem.all) for array_elem in $ident.array_elements])"
         )
     }
 

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -282,7 +282,7 @@ class VirtualMachine(
                             listOf(index.value.toInt()),
                             it,
                             it.pointer,
-                            animationString = it.animationString,
+                            animationString = it.animationStyle,
                             runtime = it.animationTime
                         )
                     )
@@ -385,7 +385,7 @@ class VirtualMachine(
                                 listOf(index.value.toInt()),
                                 this,
                                 this.pointer,
-                                animationString = this.animationString
+                                animationString = this.animationStyle
                             )
                         )
                         linearRepresentation.add(

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -275,8 +275,7 @@ class VirtualMachine(
                 RuntimeError(value = "Array index out of bounds", lineNumber = arrayElemNode.lineNumber)
             } else {
                 arrayValue.array[index.value.toInt()] = assignedValue
-                val style = arrayValue.animatedStyle
-                style?.let {
+                arrayValue.animatedStyle?.let {
                     linearRepresentation.add(
                         ArrayElemRestyle(
                             (arrayValue.manimObject as ArrayStructure).ident,
@@ -294,7 +293,7 @@ class VirtualMachine(
                         arrayValue.animatedStyle
                     )
                 )
-                if (arrayValue.animatedStyle != null) {
+                arrayValue.animatedStyle?.let {
                     linearRepresentation.add(
                         ArrayElemRestyle(
                             (arrayValue.manimObject as ArrayStructure).ident,
@@ -383,7 +382,8 @@ class VirtualMachine(
                                 (arrayValue.manimObject as ArrayStructure).ident,
                                 listOf(index.value.toInt()),
                                 this,
-                                this.pointer
+                                this.pointer,
+                                this.animationString
                             )
                         )
                         linearRepresentation.add(

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -281,7 +281,8 @@ class VirtualMachine(
                             (arrayValue.manimObject as ArrayStructure).ident,
                             listOf(index.value.toInt()),
                             it,
-                            it.pointer
+                            it.pointer,
+                            animationString = it.animationString
                         )
                     )
                 }
@@ -383,7 +384,7 @@ class VirtualMachine(
                                 listOf(index.value.toInt()),
                                 this,
                                 this.pointer,
-                                this.animationString
+                                animationString = this.animationString
                             )
                         )
                         linearRepresentation.add(

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -559,7 +559,7 @@ class VirtualMachine(
                             color = stackValue.style.borderColor,
                             textColor = stackValue.style.textColor,
                             creationStyle = stackValue.style.creationStyle,
-                            creationTime = stackValue.style.creationTime
+                            creationTime = stackValue.style.creationTime,
                             showLabel = stackValue.style.showLabel
                         )
                         // Add to stack of objects to keep track of identifier
@@ -637,7 +637,7 @@ class VirtualMachine(
                             color = arrayValue.style.borderColor,
                             textColor = arrayValue.style.textColor,
                             creationString = arrayValue.style.creationStyle,
-                            runtime = arrayValue.style.creationTime
+                            runtime = arrayValue.style.creationTime,
                             showLabel = arrayValue.style.showLabel
                         )
                         linearRepresentation.add(arrayStructure)

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -484,9 +484,10 @@ class VirtualMachine(
                                 rectangle.shape,
                                 dataStructureIdentifier,
                                 hasOldMObject,
-                                creationStyle = ds.style.creationStyle
+                                creationStyle = ds.style.creationStyle,
+                                runtime = ds.animatedStyle?.animationTime
                             ),
-                            RestyleObject(rectangle.shape, ds.style)
+                            RestyleObject(rectangle.shape, ds.style, ds.animatedStyle?.animationTime)
                         )
                     if (!hasOldMObject) {
                         instructions.add(0, rectangle)
@@ -513,10 +514,11 @@ class VirtualMachine(
                         StackPopObject(
                             topOfStack.shape,
                             dataStructureIdentifier,
-                            insideMethodCall
+                            insideMethodCall,
+                            runtime = ds.animatedStyle?.animationTime
                         )
                     )
-                    ds.animatedStyle?.let { instructions.add(0, RestyleObject(topOfStack.shape, it)) }
+                    ds.animatedStyle?.let { instructions.add(0, RestyleObject(topOfStack.shape, it, it.animationTime)) }
                     linearRepresentation.addAll(instructions)
                     return if (isExpression) poppedValue else EmptyValue
                 }
@@ -556,7 +558,8 @@ class VirtualMachine(
                             assignLHS.identifier,
                             color = stackValue.style.borderColor,
                             textColor = stackValue.style.textColor,
-                            creationStyle = stackValue.style.creationStyle
+                            creationStyle = stackValue.style.creationStyle,
+                            creationTime = stackValue.style.creationTime
                         )
                         // Add to stack of objects to keep track of identifier
                         Pair(listOf(stackInit), stackInit)
@@ -570,7 +573,8 @@ class VirtualMachine(
                             numStack.manimObject.shape,
                             color = stackValue.style.borderColor,
                             textColor = stackValue.style.textColor,
-                            creationStyle = stackValue.style.creationStyle
+                            creationStyle = stackValue.style.creationStyle,
+                            creationTime = stackValue.style.creationTime
                         )
                         Pair(listOf(stackInit), stackInit)
                     }
@@ -593,7 +597,7 @@ class VirtualMachine(
                         clonedValue.manimObject = newRectangle
                         stackValue.stack.push(clonedValue)
                         linearRepresentation.add(newRectangle)
-                        linearRepresentation.add(StackPushObject(rectangle, initStructureIdent))
+                        linearRepresentation.add(StackPushObject(rectangle, initStructureIdent, runtime = newObjectStyle.animate?.animationTime))
                     }
                     stackValue.manimObject = newObject
                     stackValue

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -554,6 +554,7 @@ class VirtualMachine(
                             assignLHS.identifier,
                             color = stackValue.style.borderColor,
                             textColor = stackValue.style.textColor,
+                            creationStyle = stackValue.style.creationStyle
                         )
                         // Add to stack of objects to keep track of identifier
                         Pair(listOf(stackInit), stackInit)
@@ -567,6 +568,7 @@ class VirtualMachine(
                             numStack.manimObject.shape,
                             color = stackValue.style.borderColor,
                             textColor = stackValue.style.textColor,
+                            creationStyle = stackValue.style.creationStyle
                         )
                         Pair(listOf(stackInit), stackInit)
                     }

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -282,7 +282,8 @@ class VirtualMachine(
                             listOf(index.value.toInt()),
                             it,
                             it.pointer,
-                            animationString = it.animationString
+                            animationString = it.animationString,
+                            runtime = it.animationTime
                         )
                     )
                 }
@@ -630,7 +631,8 @@ class VirtualMachine(
                             arrayValue.array.clone(),
                             color = arrayValue.style.borderColor,
                             textColor = arrayValue.style.textColor,
-                            creationString = arrayValue.style.creationStyle
+                            creationString = arrayValue.style.creationStyle,
+                            runtime = arrayValue.style.creationTime
                         )
                         linearRepresentation.add(arrayStructure)
                         arrayValue.manimObject = arrayStructure

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -431,10 +431,11 @@ class VirtualMachine(
                                 Pair(index1, index2),
                                 variableNameGenerator.generateNameFromPrefix("elem1"),
                                 variableNameGenerator.generateNameFromPrefix("elem2"),
-                                variableNameGenerator.generateNameFromPrefix("animations")
+                                variableNameGenerator.generateNameFromPrefix("animations"),
+                                runtime = ds.animatedStyle?.animationTime
                             )
                         } else {
-                            ArrayShortSwap(arrayIdent, Pair(index1, index2))
+                            ArrayShortSwap(arrayIdent, Pair(index1, index2), runtime = ds.animatedStyle?.animationTime)
                         }
                     val swap = mutableListOf(arraySwap)
                     with(ds.animatedStyle) {

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -613,7 +613,8 @@ class VirtualMachine(
                             assignLHS.identifier,
                             arrayValue.array.clone(),
                             color = arrayValue.style.borderColor,
-                            textColor = arrayValue.style.textColor
+                            textColor = arrayValue.style.textColor,
+                            creationString = arrayValue.style.creationStyle
                         )
                         linearRepresentation.add(arrayStructure)
                         arrayValue.manimObject = arrayStructure

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -482,7 +482,8 @@ class VirtualMachine(
                             StackPushObject(
                                 rectangle.shape,
                                 dataStructureIdentifier,
-                                hasOldMObject
+                                hasOldMObject,
+                                creationStyle = ds.style.creationStyle
                             ),
                             RestyleObject(rectangle.shape, ds.style)
                         )

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -25,7 +25,7 @@ sealed class Shape {
 sealed class ShapeWithText : Shape()
 
 interface StyleableShape {
-    fun restyle(styleProperties: StylesheetProperty): List<String>
+    fun restyle(styleProperties: StylesheetProperty, runtime: Double?): List<String>
 }
 
 class Rectangle(
@@ -44,8 +44,9 @@ class Rectangle(
         textColor?.let { style.addStyleAttribute(TextColor(it)) }
     }
 
-    override fun restyle(styleProperties: StylesheetProperty): List<String> {
+    override fun restyle(styleProperties: StylesheetProperty, runtime: Double?): List<String> {
         val instructions = mutableListOf<String>()
+        val runtimeString = if (runtime != null) ", run_time=$runtime" else ""
 
         styleProperties.borderColor?.let { instructions.add("FadeToColor($ident.shape, ${styleProperties.handleColourValue(it)})") }
         styleProperties.textColor?.let { instructions.add("FadeToColor($ident.text, ${styleProperties.handleColourValue(it)})") }
@@ -53,7 +54,7 @@ class Rectangle(
         return if (instructions.isEmpty()) {
             emptyList()
         } else {
-            listOf("self.play(${instructions.joinToString(", ")})")
+            listOf("self.play(${instructions.joinToString(", ")}$runtimeString)")
         }
     }
 

--- a/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
+++ b/src/main/kotlin/com/manimdsl/shapes/Shapes.kt
@@ -25,7 +25,7 @@ sealed class Shape {
 sealed class ShapeWithText : Shape()
 
 interface StyleableShape {
-    fun restyle(styleProperties: StylesheetProperty, runtime: Double?): List<String>
+    fun restyle(styleProperties: StylesheetProperty, runtimeString: String): List<String>
 }
 
 class Rectangle(
@@ -44,9 +44,8 @@ class Rectangle(
         textColor?.let { style.addStyleAttribute(TextColor(it)) }
     }
 
-    override fun restyle(styleProperties: StylesheetProperty, runtime: Double?): List<String> {
+    override fun restyle(styleProperties: StylesheetProperty, runtimeString: String): List<String> {
         val instructions = mutableListOf<String>()
-        val runtimeString = if (runtime != null) ", run_time=$runtime" else ""
 
         styleProperties.borderColor?.let { instructions.add("FadeToColor($ident.shape, ${styleProperties.handleColourValue(it)})") }
         styleProperties.textColor?.let { instructions.add("FadeToColor($ident.text, ${styleProperties.handleColourValue(it)})") }

--- a/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
@@ -1,6 +1,7 @@
 package com.manimdsl.stylesheet
 
 import com.manimdsl.errorhandling.ErrorHandler
+import com.manimdsl.errorhandling.warnings.animationStyleDoesNotAcceptColorWarning
 import com.manimdsl.errorhandling.warnings.invalidStyleAttribute
 import com.manimdsl.errorhandling.warnings.undeclaredVariableStyleWarning
 import com.manimdsl.frontend.SymbolTableVisitor
@@ -10,8 +11,18 @@ object StyleSheetValidator {
     private val validCodeTracking = setOf("stepOver", "stepInto")
     private val validCreationStrings =
         setOf("FadeIn", "FadeInFromLarge", "Write", "GrowFromCenter", "ShowCreation", "DrawBorderThenFill")
+
+    // Map of valid animations to whether they accept a color
     private val validAnimationStrings =
-        setOf("FadeToColor", "Indicate", "ApplyWave", "WiggleOutThenIn", "CircleIndicate", "TurnInsideOut")
+        mapOf(
+            "FadeToColor" to true,
+            "Indicate" to true,
+            "ApplyWave" to false,
+            "WiggleOutThenIn" to false,
+            "CircleIndicate" to true,
+            "TurnInsideOut" to false
+        )
+
 
     fun validateStyleSheet(stylesheet: StylesheetFromJSON, symbolTable: SymbolTableVisitor) {
         // Check variables
@@ -47,10 +58,11 @@ object StyleSheetValidator {
     }
 
     private fun checkValidCreationStyles(styles: Collection<StyleProperties>) {
-        styles.map { style ->
+        styles.forEach { style ->
             style.creationStyle?.let {
                 if (!validCreationStrings.contains(it)) {
                     invalidStyleAttribute("creationStyle", validCreationStrings, it)
+                    // Ignores creation style if invalid and defaults to FadeIn so that Manim program compiles
                     style.creationStyle = "FadeIn"
                 }
             }
@@ -58,11 +70,22 @@ object StyleSheetValidator {
     }
 
     private fun checkValidAnimationStyles(styles: Collection<StyleProperties>) {
-        styles.map { style ->
+        styles.forEach { style ->
             style.animate?.let { animationProperties ->
-                animationProperties.animationString?.let {
-                    if (!validAnimationStrings.contains(it)) {
-                        invalidStyleAttribute("animationStyle", validAnimationStrings, it)
+                animationProperties.animationString?.let { animationString ->
+                    if (validAnimationStrings.contains(animationString)) {
+                        if (!validAnimationStrings.getOrDefault(
+                                animationString,
+                                false
+                            ) && animationProperties.textColor != null
+                        ) {
+                            val validAnimationStylesWithColor = validAnimationStrings.filter { it.value }.keys
+                            animationStyleDoesNotAcceptColorWarning(animationString, validAnimationStylesWithColor)
+                        }
+                    } else {
+                        invalidStyleAttribute("animationStyle", validAnimationStrings.keys, animationString)
+                        // Ignores animation style if invalid and defaults to FadeToColor so that Manim program compiles
+                        style.animate.animationString = "FadeToColor"
                     }
                 }
             }

--- a/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
@@ -1,7 +1,6 @@
 package com.manimdsl.stylesheet
 
 import com.manimdsl.errorhandling.ErrorHandler
-import com.manimdsl.errorhandling.warnings.animationStyleDoesNotAcceptColorWarning
 import com.manimdsl.errorhandling.warnings.invalidStyleAttribute
 import com.manimdsl.errorhandling.warnings.undeclaredVariableStyleWarning
 import com.manimdsl.frontend.SymbolTableVisitor
@@ -12,8 +11,8 @@ object StyleSheetValidator {
     private val validCreationStrings =
         setOf("FadeIn", "FadeInFromLarge", "Write", "GrowFromCenter", "ShowCreation", "DrawBorderThenFill")
 
-    // Map of valid animations to whether they accept a color
-    private val validAnimationStrings =
+    // Map of valid animations to whether they accept a color as a parameter
+    val validAnimationStrings =
         mapOf(
             "FadeToColor" to true,
             "Indicate" to true,
@@ -73,16 +72,7 @@ object StyleSheetValidator {
         styles.forEach { style ->
             style.animate?.let { animationProperties ->
                 animationProperties.animationString?.let { animationString ->
-                    if (validAnimationStrings.contains(animationString)) {
-                        if (!validAnimationStrings.getOrDefault(
-                                animationString,
-                                false
-                            ) && animationProperties.textColor != null
-                        ) {
-                            val validAnimationStylesWithColor = validAnimationStrings.filter { it.value }.keys
-                            animationStyleDoesNotAcceptColorWarning(animationString, validAnimationStylesWithColor)
-                        }
-                    } else {
+                    if (!validAnimationStrings.contains(animationString)) {
                         invalidStyleAttribute("animationStyle", validAnimationStrings.keys, animationString)
                         // Ignores animation style if invalid and defaults to FadeToColor so that Manim program compiles
                         style.animate.animationString = "FadeToColor"

--- a/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
@@ -11,7 +11,7 @@ object StyleSheetValidator {
     private val validCreationStrings =
         setOf("FadeIn", "FadeInFromLarge", "Write", "GrowFromCenter", "ShowCreation", "DrawBorderThenFill")
     private val validAnimationStrings =
-        setOf("Indicate", "ApplyWave", "WiggleOutThenIn", "CircleIndicate", "TurnInsideOut")
+        setOf("FadeToColor", "Indicate", "ApplyWave", "WiggleOutThenIn", "CircleIndicate", "TurnInsideOut")
 
     fun validateStyleSheet(stylesheet: StylesheetFromJSON, symbolTable: SymbolTableVisitor) {
         // Check variables
@@ -60,7 +60,7 @@ object StyleSheetValidator {
     private fun checkValidAnimationStyles(styles: Collection<StyleProperties>) {
         styles.map { style ->
             style.animate?.let { animationProperties ->
-                animationProperties.animationStyle?.let {
+                animationProperties.animationString?.let {
                     if (!validAnimationStrings.contains(it)) {
                         invalidStyleAttribute("animationStyle", validAnimationStrings, it)
                     }

--- a/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
@@ -71,11 +71,11 @@ object StyleSheetValidator {
     private fun checkValidAnimationStyles(styles: Collection<StyleProperties>) {
         styles.forEach { style ->
             style.animate?.let { animationProperties ->
-                animationProperties.animationString?.let { animationString ->
+                animationProperties.animationStyle?.let { animationString ->
                     if (!validAnimationStrings.contains(animationString)) {
                         invalidStyleAttribute("animationStyle", validAnimationStrings.keys, animationString)
                         // Ignores animation style if invalid and defaults to FadeToColor so that Manim program compiles
-                        style.animate.animationString = "FadeToColor"
+                        style.animate.animationStyle = "FadeToColor"
                     }
                 }
             }

--- a/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/StyleSheetValidator.kt
@@ -8,29 +8,65 @@ import com.manimdsl.frontend.SymbolTableVisitor
 object StyleSheetValidator {
     private val dataStructureStrings = setOf("Stack", "Array")
     private val validCodeTracking = setOf("stepOver", "stepInto")
+    private val validCreationStrings =
+        setOf("FadeIn", "FadeInFromLarge", "Write", "GrowFromCenter", "ShowCreation", "DrawBorderThenFill")
+    private val validAnimationStrings =
+        setOf("Indicate", "ApplyWave", "WiggleOutThenIn", "CircleIndicate", "TurnInsideOut")
 
-    fun validateStyleSheet(styleSheet: StyleSheetFromJSON, symbolTable: SymbolTableVisitor) {
+    fun validateStyleSheet(stylesheet: StylesheetFromJSON, symbolTable: SymbolTableVisitor) {
         // Check variables
-        styleSheet.variables.keys.forEach {
+        stylesheet.variables.keys.forEach {
             if (!(symbolTable.getVariableNames().contains(it))) {
                 undeclaredVariableStyleWarning(it)
             }
         }
 
         // Check data structures styles
-        styleSheet.dataStructures.keys.forEach {
+        stylesheet.dataStructures.keys.forEach {
             if (!(dataStructureStrings.contains(it))) {
                 invalidStyleAttribute("dataStructures", dataStructureStrings, it)
             }
         }
 
+
         // Check code tracking
-        if(!validCodeTracking.contains(styleSheet.codeTracking)) {
+        if (!validCodeTracking.contains(stylesheet.codeTracking)) {
             // throw warning
-            invalidStyleAttribute("codeTracking", validCodeTracking, styleSheet.codeTracking)
+            invalidStyleAttribute("codeTracking", validCodeTracking, stylesheet.codeTracking)
         }
 
+        // Check creation style strings
+        checkValidCreationStyles(stylesheet.variables.values)
+        checkValidCreationStyles(stylesheet.dataStructures.values)
+
+        // Check animation style strings
+        checkValidAnimationStyles(stylesheet.variables.values)
+        checkValidAnimationStyles(stylesheet.dataStructures.values)
+
         ErrorHandler.checkWarnings()
+    }
+
+    private fun checkValidCreationStyles(styles: Collection<StyleProperties>) {
+        styles.map { style ->
+            style.creationStyle?.let {
+                if (!validCreationStrings.contains(it)) {
+                    invalidStyleAttribute("creationStyle", validCreationStrings, it)
+                    style.creationStyle = "FadeIn"
+                }
+            }
+        }
+    }
+
+    private fun checkValidAnimationStyles(styles: Collection<StyleProperties>) {
+        styles.map { style ->
+            style.animate?.let { animationProperties ->
+                animationProperties.animationStyle?.let {
+                    if (!validAnimationStrings.contains(it)) {
+                        invalidStyleAttribute("animationStyle", validAnimationStrings, it)
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -32,7 +32,7 @@ data class AnimationProperties(
     override val borderColor: String? = null,
     override val textColor: String? = null,
     val pointer: Boolean? = null,
-    var animationString: String? = null,
+    var animationStyle: String? = null,
     var animationTime: Double? = null,
 ) : StylesheetProperty()
 

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -16,7 +16,7 @@ sealed class StylesheetProperty {
     abstract val textColor: String?
 
     fun handleColourValue(color: String?): String? {
-        if(color == null) return null
+        if (color == null) return null
         return if (color.matches(Regex("#[a-fA-F0-9]{6}"))) {
             // hex value
             "\"${color}\""
@@ -28,7 +28,12 @@ sealed class StylesheetProperty {
 
 }
 
-data class AnimationProperties(override val borderColor: String? = null, override val textColor: String? = null, val pointer: Boolean? = null) : StylesheetProperty()
+data class AnimationProperties(
+    override val borderColor: String? = null,
+    override val textColor: String? = null,
+    val pointer: Boolean? = null,
+    val animationStyle: String? = null
+) : StylesheetProperty()
 
 data class StyleProperties(
     override var borderColor: String = "BLUE",
@@ -73,7 +78,6 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
         val dataStructureStyle =
             stylesheet.dataStructures.getOrDefault(value.toString(), StyleProperties())
         val style = stylesheet.variables.getOrDefault(identifier, dataStructureStyle)
-
         return style merge dataStructureStyle
     }
 
@@ -81,7 +85,8 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
         val dataStructureStyle =
             stylesheet.dataStructures.getOrDefault(value.toString(), StyleProperties())
         val style = stylesheet.variables.getOrDefault(identifier, dataStructureStyle)
-        val animationStyle = (style.animate ?: AnimationProperties()) merge (dataStructureStyle.animate ?: AnimationProperties())
+        val animationStyle =
+            (style.animate ?: AnimationProperties()) merge (dataStructureStyle.animate ?: AnimationProperties())
         // Return null if there is no style to make sure null checks work throughout executor
         return if (animationStyle == AnimationProperties()) null else animationStyle
     }

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -33,13 +33,14 @@ data class AnimationProperties(
     override val textColor: String? = null,
     val pointer: Boolean? = null,
     var animationString: String? = null,
-    val time: Int? = null
+    var animationTime: Double? = null,
 ) : StylesheetProperty()
 
 data class StyleProperties(
     override var borderColor: String? = null,
     override var textColor: String? = null,
     var creationStyle: String? = null,
+    var creationTime: Double? = null,
     val animate: AnimationProperties? = null
 ) : StylesheetProperty()
 

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -97,10 +97,10 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
         val dataStructureStyle =
             stylesheet.dataStructures.getOrDefault(value.toString(), StyleProperties())
         val style = stylesheet.variables.getOrDefault(identifier, dataStructureStyle)
-
         val animationStyle = (style.animate ?: AnimationProperties()) merge (dataStructureStyle.animate ?: AnimationProperties())
-        // Return null if there is no style to make sure null checks work throughout executor
-        return if (animationStyle == AnimationProperties()) null else animationStyle
+
+        // Returns null if there is no style to make sure null checks work throughout executor
+        return if (animationStyle.borderColor == null && animationStyle.textColor == null) null else animationStyle
     }
 
     fun getStepIntoIsDefault(): Boolean {

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -93,9 +93,6 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
                 newStyle.textColor = "WHITE"
             }
         }
-        if (newStyle.creationStyle == null) {
-            newStyle.creationStyle = "FadeIn"
-        }
         return newStyle
     }
 

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -32,7 +32,7 @@ data class AnimationProperties(
     override val borderColor: String? = null,
     override val textColor: String? = null,
     val pointer: Boolean? = null,
-    val animationStyle: String? = null
+    val animationString: String? = null
 ) : StylesheetProperty()
 
 data class StyleProperties(

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -36,8 +36,8 @@ data class AnimationProperties(
 ) : StylesheetProperty()
 
 data class StyleProperties(
-    override var borderColor: String = "BLUE",
-    override var textColor: String = "WHITE",
+    override var borderColor: String? = null,
+    override var textColor: String? = null,
     var creationStyle: String? = null,
     val animate: AnimationProperties? = null
 ) : StylesheetProperty()

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -32,7 +32,8 @@ data class AnimationProperties(
     override val borderColor: String? = null,
     override val textColor: String? = null,
     val pointer: Boolean? = null,
-    val animationString: String? = null
+    var animationString: String? = null,
+    val time: Int? = null
 ) : StylesheetProperty()
 
 data class StyleProperties(

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -32,33 +32,36 @@ class AnimationProperties(borderColor: String? = null, textColor: String? = null
     StylesheetProperty() {
     override val borderColor: String? = handleColourValue(borderColor)
     override val textColor: String? = handleColourValue(textColor)
+    val animationStyle: String? = null
 
+    fun hasNoStyle() : Boolean = borderColor == null && textColor == null && animationStyle == null
 }
 
 class StyleProperties(
     borderColor: String? = null,
     textColor: String? = null,
+    var creationStyle: String? = null,
     val animate: AnimationProperties? = null
 ) : StylesheetProperty() {
     override var borderColor: String? = handleColourValue(borderColor)
     override var textColor: String? = handleColourValue(textColor)
 }
 
-data class StyleSheetFromJSON(
+data class StylesheetFromJSON(
     val codeTracking: String = "stepInto",
     val variables: Map<String, StyleProperties> = emptyMap(),
     val dataStructures: Map<String, StyleProperties> = emptyMap()
 )
 
 class Stylesheet(private val stylesheetPath: String?, private val symbolTableVisitor: SymbolTableVisitor) {
-    private val stylesheet: StyleSheetFromJSON
+    private val stylesheet: StylesheetFromJSON
 
     init {
         stylesheet = if (stylesheetPath != null) {
             val gson = Gson()
-            val type: Type = object : TypeToken<StyleSheetFromJSON>() {}.type
+            val type: Type = object : TypeToken<StylesheetFromJSON>() {}.type
             try {
-                val parsedStylesheet: StyleSheetFromJSON = gson.fromJson(File(stylesheetPath).readText(), type)
+                val parsedStylesheet: StylesheetFromJSON = gson.fromJson(File(stylesheetPath).readText(), type)
                 StyleSheetValidator.validateStyleSheet(parsedStylesheet, symbolTableVisitor)
                 parsedStylesheet
             } catch (e: JsonSyntaxException) {
@@ -71,7 +74,7 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
                 exitProcess(1)
             }
         } else {
-            StyleSheetFromJSON()
+            StylesheetFromJSON()
         }
     }
 
@@ -90,6 +93,9 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
                 newStyle.textColor = "WHITE"
             }
         }
+        if (newStyle.creationStyle == null) {
+            newStyle.creationStyle = "FadeIn"
+        }
         return newStyle
     }
 
@@ -100,7 +106,7 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
         val animationStyle = (style.animate ?: AnimationProperties()) merge (dataStructureStyle.animate ?: AnimationProperties())
 
         // Returns null if there is no style to make sure null checks work throughout executor
-        return if (animationStyle.borderColor == null && animationStyle.textColor == null) null else animationStyle
+        return if (animationStyle.hasNoStyle()) null else animationStyle
     }
 
     fun getStepIntoIsDefault(): Boolean {

--- a/src/main/resources/python/stack.py
+++ b/src/main/resources/python/stack.py
@@ -4,12 +4,15 @@ class Stack(DataStructure, ABC):
         super().__init__(ul, ur, ll, lr, aligned_edge, color, text_color, text_weight, font)
         self.empty = None
 
-    def create_init(self, text):
+    def create_init(self, text, creation_style=None):
+        if not creation_style:
+            creation_style = "ShowCreation"
         empty = Init_structure(text, 0, self.max_width - 2 * MED_SMALL_BUFF, color=self.color, text_color=self.text_color)
         self.empty = empty.all
         empty.all.move_to(np.array([self.width_center, self.lr[1], 0]), aligned_edge=self.aligned_edge)
         self.all.add(empty.all)
-        return ShowCreation(empty.all)
+        transform = globals()[creation_style]
+        return transform(empty.all)
 
     def push(self, obj):
         animations = []

--- a/src/main/resources/python/stack.py
+++ b/src/main/resources/python/stack.py
@@ -11,10 +11,12 @@ class Stack(DataStructure, ABC):
         self.empty = empty.all
         empty.all.move_to(np.array([self.width_center, self.lr[1], 0]), aligned_edge=self.aligned_edge)
         self.all.add(empty.all)
-        transform = globals()[creation_style]
-        return [transform(empty.text), ShowCreation(empty.shape)]
+        creation_transform = globals()[creation_style]
+        return [creation_transform(empty.text), ShowCreation(empty.shape)]
 
-    def push(self, obj):
+    def push(self, obj, creation_style=None):
+        if not creation_style:
+            creation_style = "FadeIn"
         animations = []
         obj.all.move_to(np.array([self.width_center, self.ul[1] - 0.1, 0]), UP)
         shrink, scale_factor = self.shrink_if_cross_border(obj.all)
@@ -22,7 +24,8 @@ class Stack(DataStructure, ABC):
             animations.append([shrink])
         target_width = self.all.get_width() * (scale_factor if scale_factor else 1)
         obj.all.scale(target_width / obj.all.get_width())
-        animations.append([FadeIn(obj.all)])
+        creation_transform = globals()[creation_style]
+        animations.append([creation_transform(obj.all)])
         animations.append([ApplyMethod(obj.all.next_to, self.all, np.array([0, 0.25, 0]))])
         return animations
 

--- a/src/main/resources/python/stack.py
+++ b/src/main/resources/python/stack.py
@@ -12,7 +12,7 @@ class Stack(DataStructure, ABC):
         empty.all.move_to(np.array([self.width_center, self.lr[1], 0]), aligned_edge=self.aligned_edge)
         self.all.add(empty.all)
         transform = globals()[creation_style]
-        return transform(empty.all)
+        return [transform(empty.text), ShowCreation(empty.shape)]
 
     def push(self, obj):
         animations = []

--- a/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
@@ -132,7 +132,6 @@ class ASTExecutorTests {
         ).runProgram()
 
         assertEquals(expected.toString(), actual.toString())
-
     }
 
     // Assumes syntactically correct program

--- a/src/test/kotlin/com/manimdsl/stylesheet/StylesheetIntegrationTests.kt
+++ b/src/test/kotlin/com/manimdsl/stylesheet/StylesheetIntegrationTests.kt
@@ -1,40 +1,18 @@
 package com.manimdsl.stylesheet
 
 import com.manimdsl.ManimDSLParser
-import com.manimdsl.animation.ManimProjectWriter
-import com.manimdsl.animation.ManimWriter
 import com.manimdsl.linearrepresentation.EmptyMObject
 import com.manimdsl.runtime.StackValue
 import com.manimdsl.runtime.VirtualMachine
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.PrintStream
 import java.util.*
 
 class StylesheetIntegrationTests {
     private val stylesheetPath = "src/test/testFiles/stylesheet"
     private val validTestFilePath = "src/test/testFiles/valid"
-
-    private val standardOut = System.out
-    private val outputStreamCaptor = ByteArrayOutputStream()
-
-    // To capture standard out e.g. use of println
-    @BeforeEach
-    internal fun setUp() {
-        System.setOut(PrintStream(outputStreamCaptor))
-    }
-
-    // Reset system out to stdout
-    @AfterEach
-    internal fun tearDown() {
-        System.setOut(standardOut)
-    }
 
     @Test
     fun localVariableAssignedCorrectStyle() {
@@ -45,22 +23,7 @@ class StylesheetIntegrationTests {
         assertThat(stack1Style.textColor, `is`("BLUE"))
     }
 
-    @Test
-    fun incorrectCreationStyleDoesNotGetPassedToPython() {
-        runCompiler("stackFunction.manimdsl", "incorrectCreationStyle.json", true)
-        // Pattern to recognise Manim error but not our warning
-        assertFalse(outputStreamCaptor.toString().contains(Regex(": RandomWrongTransform")))
-    }
-
-    @Test
-    fun incorrectAnimationStyleDoesNotGetPassedToPython() {
-        runCompiler("stackFunction.manimdsl", "incorrectAnimationStyle.json", true)
-        // Pattern to recognise Manim error but not our warning
-        assertFalse(outputStreamCaptor.toString().contains(Regex(": RandomWrongTransform")))
-    }
-
-
-    private fun runCompiler(fileName: String, stylesheetName: String, generateAnimation: Boolean = false): Stylesheet {
+    private fun runCompiler(fileName: String, stylesheetName: String): Stylesheet {
         val inputFile = File("$validTestFilePath/$fileName")
         val parser = ManimDSLParser(inputFile.inputStream())
         val program = parser.parseFile().second
@@ -69,18 +32,13 @@ class StylesheetIntegrationTests {
             "$stylesheetPath/$stylesheetName",
             parserResult.symbolTableVisitor
         )
-        val manimInstructions = VirtualMachine(
+        VirtualMachine(
             parserResult.abstractSyntaxTree,
             parserResult.symbolTableVisitor,
             parserResult.lineNodeMap,
             inputFile.readLines(),
             stylesheet
         ).runProgram().second
-        if (generateAnimation) {
-            val writer = ManimProjectWriter(ManimWriter(manimInstructions).build())
-            val pythonOutput = writer.createPythonFile()
-            writer.generateAnimation(pythonOutput, listOf("-l"), "out.mp4")
-        }
         return stylesheet
     }
 

--- a/src/test/kotlin/com/manimdsl/stylesheet/StylesheetIntegrationTests.kt
+++ b/src/test/kotlin/com/manimdsl/stylesheet/StylesheetIntegrationTests.kt
@@ -7,9 +7,9 @@ import com.manimdsl.linearrepresentation.EmptyMObject
 import com.manimdsl.runtime.StackValue
 import com.manimdsl.runtime.VirtualMachine
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert
 import org.junit.Assert.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
@@ -47,18 +47,16 @@ class StylesheetIntegrationTests {
 
     @Test
     fun incorrectCreationStyleDoesNotGetPassedToPython() {
-        runCompiler("stackFunction.manimdsl", "incorrectCreationStyle.json")
-        Assert.assertFalse(
-            outputStreamCaptor.toString().contains(Regex("Error"))
-        )
+        runCompiler("stackFunction.manimdsl", "incorrectCreationStyle.json", true)
+        // Pattern to recognise Manim error but not our warning
+        assertFalse(outputStreamCaptor.toString().contains(Regex(": RandomWrongTransform")))
     }
 
     @Test
     fun incorrectAnimationStyleDoesNotGetPassedToPython() {
-        runCompiler("stackFunction.manimdsl", "incorrectAnimationStyle.json")
-        Assert.assertFalse(
-            outputStreamCaptor.toString().contains(Regex("Error"))
-        )
+        runCompiler("stackFunction.manimdsl", "incorrectAnimationStyle.json", true)
+        // Pattern to recognise Manim error but not our warning
+        assertFalse(outputStreamCaptor.toString().contains(Regex(": RandomWrongTransform")))
     }
 
 
@@ -80,8 +78,8 @@ class StylesheetIntegrationTests {
         ).runProgram().second
         if (generateAnimation) {
             val writer = ManimProjectWriter(ManimWriter(manimInstructions).build())
-            writer.createPythonFile()
-            writer.generateAnimation(fileName, emptyList(),"out.mp4")
+            val pythonOutput = writer.createPythonFile()
+            writer.generateAnimation(pythonOutput, listOf("-l"), "out.mp4")
         }
         return stylesheet
     }

--- a/src/test/kotlin/com/manimdsl/stylesheet/StylesheetIntegrationTests.kt
+++ b/src/test/kotlin/com/manimdsl/stylesheet/StylesheetIntegrationTests.kt
@@ -1,0 +1,90 @@
+package com.manimdsl.stylesheet
+
+import com.manimdsl.ManimDSLParser
+import com.manimdsl.animation.ManimProjectWriter
+import com.manimdsl.animation.ManimWriter
+import com.manimdsl.linearrepresentation.EmptyMObject
+import com.manimdsl.runtime.StackValue
+import com.manimdsl.runtime.VirtualMachine
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assert
+import org.junit.Assert.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import java.util.*
+
+class StylesheetIntegrationTests {
+    private val stylesheetPath = "src/test/testFiles/stylesheet"
+    private val validTestFilePath = "src/test/testFiles/valid"
+
+    private val standardOut = System.out
+    private val outputStreamCaptor = ByteArrayOutputStream()
+
+    // To capture standard out e.g. use of println
+    @BeforeEach
+    internal fun setUp() {
+        System.setOut(PrintStream(outputStreamCaptor))
+    }
+
+    // Reset system out to stdout
+    @AfterEach
+    internal fun tearDown() {
+        System.setOut(standardOut)
+    }
+
+    @Test
+    fun localVariableAssignedCorrectStyle() {
+        val stylesheet =
+            runCompiler("stackFunction.manimdsl", "variableOverrideStylesheet.json")
+        val stack1Style = stylesheet.getStyle("stack1", StackValue(EmptyMObject, Stack()))
+        assertThat(stack1Style.borderColor, `is`("ORANGE"))
+        assertThat(stack1Style.textColor, `is`("BLUE"))
+    }
+
+    @Test
+    fun incorrectCreationStyleDoesNotGetPassedToPython() {
+        runCompiler("stackFunction.manimdsl", "incorrectCreationStyle.json")
+        Assert.assertFalse(
+            outputStreamCaptor.toString().contains(Regex("Error"))
+        )
+    }
+
+    @Test
+    fun incorrectAnimationStyleDoesNotGetPassedToPython() {
+        runCompiler("stackFunction.manimdsl", "incorrectAnimationStyle.json")
+        Assert.assertFalse(
+            outputStreamCaptor.toString().contains(Regex("Error"))
+        )
+    }
+
+
+    private fun runCompiler(fileName: String, stylesheetName: String, generateAnimation: Boolean = false): Stylesheet {
+        val inputFile = File("$validTestFilePath/$fileName")
+        val parser = ManimDSLParser(inputFile.inputStream())
+        val program = parser.parseFile().second
+        val parserResult = parser.convertToAst(program)
+        val stylesheet = Stylesheet(
+            "$stylesheetPath/$stylesheetName",
+            parserResult.symbolTableVisitor
+        )
+        val manimInstructions = VirtualMachine(
+            parserResult.abstractSyntaxTree,
+            parserResult.symbolTableVisitor,
+            parserResult.lineNodeMap,
+            inputFile.readLines(),
+            stylesheet
+        ).runProgram().second
+        if (generateAnimation) {
+            val writer = ManimProjectWriter(ManimWriter(manimInstructions).build())
+            writer.createPythonFile()
+            writer.generateAnimation(fileName, emptyList(),"out.mp4")
+        }
+        return stylesheet
+    }
+
+
+}

--- a/src/test/kotlin/com/manimdsl/stylesheet/StylesheetTests.kt
+++ b/src/test/kotlin/com/manimdsl/stylesheet/StylesheetTests.kt
@@ -7,9 +7,10 @@ import com.manimdsl.frontend.StackType
 import com.manimdsl.frontend.SymbolTableVisitor
 import com.manimdsl.linearrepresentation.EmptyMObject
 import com.manimdsl.runtime.StackValue
+import com.manimdsl.runtime.VirtualMachine
 import org.hamcrest.CoreMatchers.`is`
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.util.*
@@ -67,8 +68,10 @@ class StylesheetTests {
     @Test
     fun defaultCodeTrackingIsStepInto() {
         val stylesheet = Stylesheet(null, SymbolTableVisitor())
-        assertEquals(true, stylesheet.getStepIntoIsDefault())
+        assertTrue(stylesheet.getStepIntoIsDefault())
     }
+
+
 
     private fun getStylesheetAfterRunningVirtualMachine(fileName: String, stylesheetName: String): Stylesheet {
         val inputFile = File("src/test/testFiles/valid/$fileName")
@@ -79,7 +82,7 @@ class StylesheetTests {
             "$stylesheetPath/$stylesheetName",
             parserResult.symbolTableVisitor
         )
-//        VirtualMachine(parserResult.abstractSyntaxTree, parserResult.symbolTableVisitor, parserResult.lineNodeMap, inputFile.readLines(), stylesheet).runProgram()
+        VirtualMachine(parserResult.abstractSyntaxTree, parserResult.symbolTableVisitor, parserResult.lineNodeMap, inputFile.readLines(), stylesheet).runProgram()
         return stylesheet
     }
 

--- a/src/test/kotlin/com/manimdsl/stylesheet/StylesheetUnitTests.kt
+++ b/src/test/kotlin/com/manimdsl/stylesheet/StylesheetUnitTests.kt
@@ -1,21 +1,18 @@
 package com.manimdsl.stylesheet
 
-import com.manimdsl.ManimDSLParser
 import com.manimdsl.frontend.IdentifierData
 import com.manimdsl.frontend.NumberType
 import com.manimdsl.frontend.StackType
 import com.manimdsl.frontend.SymbolTableVisitor
 import com.manimdsl.linearrepresentation.EmptyMObject
 import com.manimdsl.runtime.StackValue
-import com.manimdsl.runtime.VirtualMachine
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.io.File
 import java.util.*
 
-class StylesheetTests {
+class StylesheetUnitTests {
     private val stylesheetPath = "src/test/testFiles/stylesheet"
 
     @Test
@@ -28,6 +25,7 @@ class StylesheetTests {
         ).getStyle("stack1", StackValue(EmptyMObject, Stack()))
         assertThat(stack1Style.borderColor, `is`("ORANGE"))
         assertThat(stack1Style.textColor, `is`("BLUE"))
+        assertThat(stack1Style.creationStyle, `is`("DrawBorderThenFill"))
     }
 
     @Test
@@ -40,6 +38,7 @@ class StylesheetTests {
         ).getStyle("stack1", StackValue(EmptyMObject, Stack()))
         assertThat(stack1Style.borderColor, `is`("YELLOW"))
         assertThat(stack1Style.textColor, `is`("GREEN"))
+        assertThat(stack1Style.animate!!.animationStyle, `is`("CircleIndicate"))
     }
 
     @Test
@@ -51,18 +50,12 @@ class StylesheetTests {
         val stack1Style = stack1Stylesheet.getStyle("stack1", StackValue(EmptyMObject, Stack()))
         assertThat(stack1Style.borderColor, `is`("YELLOW"))
         assertThat(stack1Style.textColor, `is`("BLUE"))
+        assertThat(stack1Style.creationStyle, `is`("GrowFromCenter"))
 
         val stack1AnimationStyle = stack1Stylesheet.getAnimatedStyle("stack1", StackValue(EmptyMObject, Stack()))!!
         assertThat(stack1AnimationStyle.borderColor, `is`("BLUE"))
         assertThat(stack1AnimationStyle.textColor, `is`("RED"))
-    }
-
-    @Test
-    fun localVariableAssignedCorrectStyle() {
-        val stylesheet = getStylesheetAfterRunningVirtualMachine("stackFunction.manimdsl", "variableOverrideStylesheet.json")
-        val stack1Style = stylesheet.getStyle("stack1", StackValue(EmptyMObject, Stack()))
-        assertThat(stack1Style.borderColor, `is`("ORANGE"))
-        assertThat(stack1Style.textColor, `is`("BLUE"))
+        assertThat(stack1AnimationStyle.animationStyle, `is`("ApplyWave"))
     }
 
     @Test
@@ -72,18 +65,5 @@ class StylesheetTests {
     }
 
 
-
-    private fun getStylesheetAfterRunningVirtualMachine(fileName: String, stylesheetName: String): Stylesheet {
-        val inputFile = File("src/test/testFiles/valid/$fileName")
-        val parser = ManimDSLParser(inputFile.inputStream())
-        val program = parser.parseFile().second
-        val parserResult = parser.convertToAst(program)
-        val stylesheet = Stylesheet(
-            "$stylesheetPath/$stylesheetName",
-            parserResult.symbolTableVisitor
-        )
-        VirtualMachine(parserResult.abstractSyntaxTree, parserResult.symbolTableVisitor, parserResult.lineNodeMap, inputFile.readLines(), stylesheet).runProgram()
-        return stylesheet
-    }
 
 }

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -19,7 +19,7 @@ class Main(Scene):
         self.move_arrow_to_line(1, pointer, code_block, code_text)
         # Constructing new Stack<number> "y"
         stack = Stack([5.0, 4.0, 0], [7.0, 4.0, 0], [5.0, -4.0, 0], [7.0, -4.0, 0], DOWN)
-        self.play(*stack.create_init("stack"))
+        self.play(*stack.create_init("y"))
         self.move_arrow_to_line(2, pointer, code_block, code_text)
         # Constructs a new Rectangle_block with value 2.0
         rectangle = Rectangle_block("2.0", stack)

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -164,12 +164,15 @@ class Stack(DataStructure, ABC):
     def __init__(self, ul, ur, ll, lr, aligned_edge, color=WHITE, text_color=WHITE, text_weight=NORMAL,font="Times New Roman"):
         super().__init__(ul, ur, ll, lr, aligned_edge, color, text_color, text_weight, font)
         self.empty = None
-    def create_init(self, text):
+    def create_init(self, text, creation_style=None):
+        if not creation_style:
+            creation_style = "ShowCreation"
         empty = Init_structure(text, 0, self.max_width - 2 * MED_SMALL_BUFF, color=self.color, text_color=self.text_color)
         self.empty = empty.all
         empty.all.move_to(np.array([self.width_center, self.lr[1], 0]), aligned_edge=self.aligned_edge)
         self.all.add(empty.all)
-        return ShowCreation(empty.all)
+        transform = globals()[creation_style]
+        return transform(empty.all)
     def push(self, obj):
         animations = []
         obj.all.move_to(np.array([self.width_center, self.ul[1] - 0.1, 0]), UP)

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -19,7 +19,7 @@ class Main(Scene):
         self.move_arrow_to_line(1, pointer, code_block, code_text)
         # Constructing new Stack<number> "y"
         stack = Stack([5.0, 4.0, 0], [7.0, 4.0, 0], [5.0, -4.0, 0], [7.0, -4.0, 0], DOWN)
-        self.play(stack.create_init("y"))
+        self.play(*stack.create_init("y"))
         self.move_arrow_to_line(2, pointer, code_block, code_text)
         # Constructs a new Rectangle_block with value 2.0
         rectangle = Rectangle_block("2.0", stack)
@@ -171,9 +171,11 @@ class Stack(DataStructure, ABC):
         self.empty = empty.all
         empty.all.move_to(np.array([self.width_center, self.lr[1], 0]), aligned_edge=self.aligned_edge)
         self.all.add(empty.all)
-        transform = globals()[creation_style]
-        return transform(empty.all)
-    def push(self, obj):
+        creation_transform = globals()[creation_style]
+        return [creation_transform(empty.text), ShowCreation(empty.shape)]
+    def push(self, obj, creation_style=None):
+        if not creation_style:
+            creation_style = "FadeIn"
         animations = []
         obj.all.move_to(np.array([self.width_center, self.ul[1] - 0.1, 0]), UP)
         shrink, scale_factor = self.shrink_if_cross_border(obj.all)
@@ -181,7 +183,8 @@ class Stack(DataStructure, ABC):
             animations.append([shrink])
         target_width = self.all.get_width() * (scale_factor if scale_factor else 1)
         obj.all.scale(target_width / obj.all.get_width())
-        animations.append([FadeIn(obj.all)])
+        creation_transform = globals()[creation_style]
+        animations.append([creation_transform(obj.all)])
         animations.append([ApplyMethod(obj.all.next_to, self.all, np.array([0, 0.25, 0]))])
         return animations
     def pop(self, obj, fade_out=True):

--- a/src/test/testFiles/stylesheet/incorrectAnimationStyle.json
+++ b/src/test/testFiles/stylesheet/incorrectAnimationStyle.json
@@ -2,10 +2,10 @@
   "dataStructures": {
     "Stack": {
       "borderColor": "YELLOW",
-      "creationStyle": "Write",
       "animate": {
-        "textColor": "RED",
-        "animationStyle": "Indicate"
+        "animationStyle": "RandomWrongTransform",
+        "borderColor": "RED",
+        "textColor": "RED"
       }
     }
   }

--- a/src/test/testFiles/stylesheet/incorrectCreationStyle.json
+++ b/src/test/testFiles/stylesheet/incorrectCreationStyle.json
@@ -1,11 +1,11 @@
 {
   "dataStructures": {
     "Stack": {
+      "creationStyle": "RandomWrongTransform",
       "borderColor": "YELLOW",
-      "creationStyle": "Write",
       "animate": {
-        "textColor": "RED",
-        "animationStyle": "Indicate"
+        "borderColor": "RED",
+        "textColor": "RED"
       }
     }
   }

--- a/src/test/testFiles/stylesheet/mixedStylesheet.json
+++ b/src/test/testFiles/stylesheet/mixedStylesheet.json
@@ -3,16 +3,19 @@
     "stack1": {
       "textColor": "BLUE",
       "animate": {
-        "borderColor": "BLUE"
+        "borderColor": "BLUE",
+        "animationStyle": "ApplyWave"
       }
     }
   },
   "dataStructures": {
     "Stack": {
       "borderColor": "YELLOW",
+      "creationStyle": "GrowFromCenter",
       "animate": {
         "borderColor": "RED",
-        "textColor": "RED"
+        "textColor": "RED",
+        "animationStyle": "FadeToColor"
       }
     }
   }

--- a/src/test/testFiles/stylesheet/stackTypeStylesheet.json
+++ b/src/test/testFiles/stylesheet/stackTypeStylesheet.json
@@ -5,7 +5,8 @@
       "textColor": "GREEN",
       "animate": {
         "borderColor": "RED",
-        "textColor": "RED"
+        "textColor": "RED",
+        "animationStyle": "CircleIndicate"
       }
     }
   }

--- a/src/test/testFiles/stylesheet/variableOverrideStylesheet.json
+++ b/src/test/testFiles/stylesheet/variableOverrideStylesheet.json
@@ -1,12 +1,14 @@
 {
   "variables": {
     "stack1": {
+      "creationStyle": "DrawBorderThenFill",
       "textColor": "BLUE",
       "borderColor": "ORANGE"
     }
   },
   "dataStructures": {
     "Stack": {
+      "creationStyle": "Write",
       "borderColor": "YELLOW",
       "textColor": "GREEN",
       "animate": {

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -1,9 +1,9 @@
 {
   "hideCode": true,
   "dataStructures": {
-    "Array": {
+    "Stack": {
       "borderColor": "YELLOW",
-      "creationStyle": "DrawBorderThenFill",
+      "creationStyle": "GrowFromCenter",
       "animate": {
         "textColor": "RED",
         "animationString": "Indicate"

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -1,7 +1,7 @@
 {
   "hideCode": true,
   "dataStructures": {
-    "Array": {
+    "Stack": {
       "borderColor": "YELLOW",
       "creationStyle": "Write",
       "creationTime": 6,

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -3,8 +3,10 @@
   "dataStructures": {
     "Array": {
       "borderColor": "YELLOW",
+      "creationStyle": "DrawBorderThenFill",
       "animate": {
-        "textColor": "RED"
+        "textColor": "RED",
+        "animationString": "ApplyWave"
       }
     }
   }

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -3,7 +3,7 @@
   "dataStructures": {
     "Stack": {
       "borderColor": "YELLOW",
-      "creationStyle": "GrowFromCenter",
+      "creationStyle": "Write",
       "animate": {
         "textColor": "RED",
         "animationString": "Indicate"

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -6,7 +6,7 @@
       "creationStyle": "DrawBorderThenFill",
       "animate": {
         "textColor": "RED",
-        "animationString": "ApplyWave"
+        "animationString": "Indicate"
       }
     }
   }

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -7,7 +7,7 @@
       "creationTime": 6,
       "animate": {
         "textColor": "RED",
-        "animationString": "Indicate",
+        "animationStyle": "Indicate",
         "animationTime": 0.4
       }
     }

--- a/test_stylesheet.json
+++ b/test_stylesheet.json
@@ -1,12 +1,14 @@
 {
   "hideCode": true,
   "dataStructures": {
-    "Stack": {
+    "Array": {
       "borderColor": "YELLOW",
       "creationStyle": "Write",
+      "creationTime": 6,
       "animate": {
         "textColor": "RED",
-        "animationString": "Indicate"
+        "animationString": "Indicate",
+        "animationTime": 0.4
       }
     }
   }


### PR DESCRIPTION
### Clubhouse Ticket
[ch209](https://app.clubhouse.io/manim-dsl/story/209/extend-style-sheet-with-animation-options)

### Description

Extended stylesheet to allow user to specify the animation style they would like to see when a data structure is *created* (e.g., `ShowCreation`, `Write`) and when it is *animated* (e.g., `FadeToColor`, `Indicate`), through the new `creationStyle` and `animationStyle` properties. Also allowed the user to specify the runtime of data structure creation and animation, using `creationTime` and `animationTime`.

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?

WIP

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes