### PR TITLE
Feature/ch304/reset animation positions for placement

### DIFF
--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.util.concurrent.Callable
 import kotlin.system.exitProcess
 
-private fun compile(filename: String, outputVideoFile:String, generatePython: Boolean, onlyGenerateManim : Boolean, manimOptions: List<String>, stylesheetPath: String?, boundaries: BoundaryCalculationOptions) {
+private fun compile(filename: String, outputVideoFile:String, generatePython: Boolean, onlyGenerateManim : Boolean, manimOptions: List<String>, stylesheetPath: String?, boundaries: Boolean) {
     val file = File(filename)
     if (!file.isFile) {
         // File argument was not valid
@@ -42,7 +42,7 @@ private fun compile(filename: String, outputVideoFile:String, generatePython: Bo
 
     val (runtimeErrorStatus, manimInstructions) = VirtualMachine(abstractSyntaxTree, symbolTable, lineNodeMap, file.readLines(), stylesheet, boundaries).runProgram()
 
-    if(boundaries != BoundaryCalculationOptions.NONE) {
+    if(boundaries) {
         exitProcess(runtimeErrorStatus.code)
     }
 
@@ -85,17 +85,6 @@ enum class AnimationQuality {
     }
 }
 
-enum class BoundaryCalculationOptions {
-    STYLESHEET,
-    AUTO,
-    NONE;
-
-    override fun toString(): String {
-        return this.name.toLowerCase()
-    }
-}
-
-
 @Command(
     name = "manimdsl",
     mixinStandardHelpOptions = true,
@@ -122,7 +111,7 @@ class DSLCommandLineArguments : Callable<Int> {
     var manim: Boolean = false
 
     @Option(names = ["-b", "--boundaries"], description = ["Print out boundaries of shapes"], hidden = true)
-    var boundaries: BoundaryCalculationOptions = BoundaryCalculationOptions.NONE
+    var boundaries: Boolean = false
 
     @Option(
         names = ["-q", "--quality"],

--- a/src/main/kotlin/com/manimdsl/Compiler.kt
+++ b/src/main/kotlin/com/manimdsl/Compiler.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.util.concurrent.Callable
 import kotlin.system.exitProcess
 
-private fun compile(filename: String, outputVideoFile:String, generatePython: Boolean, onlyGenerateManim : Boolean, manimOptions: List<String>, stylesheetPath: String?, boundaries: Boolean) {
+private fun compile(filename: String, outputVideoFile:String, generatePython: Boolean, onlyGenerateManim : Boolean, manimOptions: List<String>, stylesheetPath: String?, boundaries: BoundaryCalculationOptions) {
     val file = File(filename)
     if (!file.isFile) {
         // File argument was not valid
@@ -42,7 +42,7 @@ private fun compile(filename: String, outputVideoFile:String, generatePython: Bo
 
     val (runtimeErrorStatus, manimInstructions) = VirtualMachine(abstractSyntaxTree, symbolTable, lineNodeMap, file.readLines(), stylesheet, boundaries).runProgram()
 
-    if(boundaries) {
+    if(boundaries != BoundaryCalculationOptions.NONE) {
         exitProcess(runtimeErrorStatus.code)
     }
 
@@ -85,6 +85,17 @@ enum class AnimationQuality {
     }
 }
 
+enum class BoundaryCalculationOptions {
+    STYLESHEET,
+    AUTO,
+    NONE;
+
+    override fun toString(): String {
+        return this.name.toLowerCase()
+    }
+}
+
+
 @Command(
     name = "manimdsl",
     mixinStandardHelpOptions = true,
@@ -111,7 +122,7 @@ class DSLCommandLineArguments : Callable<Int> {
     var manim: Boolean = false
 
     @Option(names = ["-b", "--boundaries"], description = ["Print out boundaries of shapes"], hidden = true)
-    var boundaries: Boolean = false
+    var boundaries: BoundaryCalculationOptions = BoundaryCalculationOptions.NONE
 
     @Option(
         names = ["-q", "--quality"],

--- a/src/main/kotlin/com/manimdsl/executor/DataStructureShapes.kt
+++ b/src/main/kotlin/com/manimdsl/executor/DataStructureShapes.kt
@@ -2,8 +2,7 @@ package com.manimdsl.executor
 
 import com.manimdsl.ExitStatus
 import com.manimdsl.errorhandling.ErrorHandler
-
-data class Positioning(val x: Double, val y: Double, val width: Double, val height: Double)
+import com.manimdsl.stylesheet.PositionProperties
 
 sealed class BoundaryShape(var x1: Double = 0.0, var y1: Double = 0.0) {
 
@@ -31,8 +30,8 @@ sealed class BoundaryShape(var x1: Double = 0.0, var y1: Double = 0.0) {
         return listOf(Pair(x1, y1 + height), Pair(x1 + width, y1 + height), Pair(x1, y1), Pair(x1 + width, y1))
     }
 
-    fun positioning() : Positioning {
-        return Positioning(x1, y1, width, height)
+    fun positioning() : PositionProperties {
+        return PositionProperties(x1, y1, width, height)
     }
 
     fun area(): Double {

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -20,7 +20,7 @@ class VirtualMachine(
     private val statements: MutableMap<Int, StatementNode>,
     private val fileLines: List<String>,
     private val stylesheet: Stylesheet,
-    private val returnBoundaries: Boolean
+    private val returnBoundaries: Boolean = false
 ) {
 
     private val linearRepresentation = mutableListOf<ManimInstr>()

--- a/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/ASTExecutor.kt
@@ -1,12 +1,13 @@
 package com.manimdsl.runtime
 
-import com.google.gson.Gson
+import com.manimdsl.BoundaryCalculationOptions
 import com.manimdsl.ExitStatus
 import com.manimdsl.errorhandling.ErrorHandler.addRuntimeError
 import com.manimdsl.executor.*
 import com.manimdsl.frontend.*
 import com.manimdsl.linearrepresentation.*
 import com.manimdsl.runtime.utility.getBoundaries
+import com.manimdsl.runtime.utility.printPositioning
 import com.manimdsl.runtime.utility.wrapCode
 import com.manimdsl.shapes.Rectangle
 import com.manimdsl.stylesheet.Stylesheet
@@ -19,7 +20,7 @@ class VirtualMachine(
     private val statements: MutableMap<Int, StatementNode>,
     private val fileLines: List<String>,
     private val stylesheet: Stylesheet,
-    private val returnBoundaries: Boolean = false
+    private val returnBoundaries: BoundaryCalculationOptions = BoundaryCalculationOptions.NONE
 ) {
 
     private val linearRepresentation = mutableListOf<ManimInstr>()
@@ -81,11 +82,10 @@ class VirtualMachine(
         return if (result is RuntimeError) {
             addRuntimeError(result.value, result.lineNumber)
             Pair(ExitStatus.RUNTIME_ERROR, linearRepresentation)
-        } else if (!stylesheet.userDefinedPositions()) {
+        } else if (returnBoundaries == BoundaryCalculationOptions.AUTO || !stylesheet.userDefinedPositions()) {
             val (exitStatus, computedBoundaries) = Scene().compute(dataStructureBoundaries.toList(), hideCode)
-            if (returnBoundaries) {
-                val gson = Gson()
-                println(gson.toJson(computedBoundaries.map { it.key to it.value.positioning() }.toMap()))
+            if (returnBoundaries != BoundaryCalculationOptions.NONE) {
+                printPositioning(computedBoundaries.mapValues { it.value.positioning() })
             }
             if (exitStatus != ExitStatus.EXIT_SUCCESS) {
                 return Pair(exitStatus, linearRepresentation)
@@ -99,6 +99,9 @@ class VirtualMachine(
             }
             Pair(ExitStatus.EXIT_SUCCESS, linearRepresentationWithBoundaries)
         } else {
+            if(returnBoundaries == BoundaryCalculationOptions.STYLESHEET) {
+                printPositioning(stylesheet.getPositions().filter { it.key in dataStructureBoundaries.keys })
+            }
             linearRepresentation.forEach {
                 if (it is DataStructureMObject) {
                     it.setShape()

--- a/src/main/kotlin/com/manimdsl/runtime/utility/UtilityFunctions.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/utility/UtilityFunctions.kt
@@ -1,6 +1,5 @@
 package com.manimdsl.runtime.utility
 
-import com.google.gson.Gson
 import com.manimdsl.stylesheet.PositionProperties
 
 private val WRAP_LINE_LENGTH = 50
@@ -45,9 +44,4 @@ fun getBoundaries(position: PositionProperties?): List<Pair<Double, Double>> {
         boundaries.addAll(listOf(Pair(left, top), Pair(right, top), Pair(left, bottom), Pair(right, bottom)))
     }
     return boundaries
-}
-
-fun printPositioning(boundaries: Map<String, PositionProperties>) {
-    val gson = Gson()
-    println(gson.toJson(boundaries))
 }

--- a/src/main/kotlin/com/manimdsl/runtime/utility/UtilityFunctions.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/utility/UtilityFunctions.kt
@@ -1,5 +1,6 @@
 package com.manimdsl.runtime.utility
 
+import com.google.gson.Gson
 import com.manimdsl.stylesheet.PositionProperties
 
 private val WRAP_LINE_LENGTH = 50
@@ -44,4 +45,9 @@ fun getBoundaries(position: PositionProperties?): List<Pair<Double, Double>> {
         boundaries.addAll(listOf(Pair(left, top), Pair(right, top), Pair(left, bottom), Pair(right, bottom)))
     }
     return boundaries
+}
+
+fun printPositioning(boundaries: Map<String, PositionProperties>) {
+    val gson = Gson()
+    println(gson.toJson(boundaries))
 }

--- a/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
+++ b/src/main/kotlin/com/manimdsl/stylesheet/Stylesheet.kt
@@ -106,6 +106,10 @@ class Stylesheet(private val stylesheetPath: String?, private val symbolTableVis
         return if (animationStyle == AnimationProperties()) null else animationStyle
     }
 
+    fun getPositions(): Map<String, PositionProperties> {
+        return stylesheet.positions
+    }
+
     fun getPosition(identifier: String): PositionProperties? {
         return stylesheet.positions[identifier]
     }

--- a/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTExecutorTests.kt
@@ -82,8 +82,7 @@ class ASTExecutorTests {
             symbolTable,
             lineNodeMap,
             program.split("\n"),
-            Stylesheet(null, symbolTable),
-            false
+            Stylesheet(null, symbolTable)
         ).runProgram()
         assertEquals(expected.toString(), actual.toString())
     }


### PR DESCRIPTION
### Clubhouse Ticket
[ch304](https://app.clubhouse.io/manim-dsl/story/304/reset-animation-positions-for-placement)

### Description

Added more to output to get both auto calculated and stylesheet positioning. Required for Web UI placement

Fixes # (issue) 

### Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe tests added as well.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules