### PR TITLE
Fixed small bug where runtime was passed twice in stack pop object

### DIFF
--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -176,7 +176,7 @@ data class StackPopObject(
     override fun toPython(): List<String> {
         return listOf(
             "[self.play(*animation${getRuntimeString()}) for animation in $dataStructureIdentifier.pop(${shape.ident}, fade_out=${(!insideMethodCall).toString()
-                .capitalize()}${getRuntimeString()})]"
+                .capitalize()})]"
         )
     }
 }

--- a/src/test/testFiles/python/stack.py
+++ b/src/test/testFiles/python/stack.py
@@ -32,7 +32,7 @@ class Main(Scene):
         [self.play(*animation, run_time=1.0) for animation in stack.push(rectangle1)]
         stack.add(rectangle1.all)
         self.move_arrow_to_line(4, pointer, code_block, code_text)
-        [self.play(*animation, run_time=1.0) for animation in stack.pop(rectangle1, fade_out=True, run_time=1.0)]
+        [self.play(*animation, run_time=1.0) for animation in stack.pop(rectangle1, fade_out=True)]
     def place_at(self, group, x, y):
         group.to_edge(np.array([x, y, 0]))
     def move_relative_to_edge(self, group, x, y):


### PR DESCRIPTION
### Description

Fixed small bug where runtime was passed twice in stack pop object

Fixes # (issue) 
Fixed small bug where runtime was passed twice in stack pop object
### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue) 🐛 

### How Has This Been Tested?

Please describe tests added as well.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules