### PR TITLE
Implement subtitle decorator on frontend

### DIFF
--- a/antlr_config/ManimLexer.g4
+++ b/antlr_config/ManimLexer.g4
@@ -60,11 +60,15 @@ IN: 'in';
 RANGE: 'range';
 BREAK: 'break';
 CONTINUE: 'continue';
-STEP_INTO: 'stepInto';
-STEP_OVER: 'stepOver';
-SPEED: 'speed';
 TO_NUMBER: 'toNumber';
 TO_CHAR: 'toChar';
+
+// annotations
+STEP_INTO: '@stepInto';
+STEP_OVER: '@stepOver';
+SPEED: '@speed';
+SUBTITLE: '@subtitle';
+SUBTITLE_ONCE: '@subtitleOnce';
 
 NULL: 'null';
 IDENT: ('a'..'z' | 'A'..'Z')('0'..'9' | 'a'..'z' | 'A'..'Z' | '_')* ;

--- a/antlr_config/ManimParser.g4
+++ b/antlr_config/ManimParser.g4
@@ -27,11 +27,17 @@ stat: SLEEP OPEN_PARENTHESIS expr CLOSE_PARENTHESIS SEMI                 #SleepS
     | stat1=stat stat2=stat                                              #ConsecutiveStatement
     | method_call SEMI                                                   #MethodCallStatement
     | RETURN expr? SEMI                                                  #ReturnStatement
-    | AT annotation                                                      #AnnotationStatement
+    | annotation                                                         #AnnotationStatement
     ;
 
-annotation: step=(STEP_INTO | STEP_OVER) (OPEN_PARENTHESIS condition=expr CLOSE_PARENTHESIS)? OPEN_CURLY_BRACKET stat CLOSE_CURLY_BRACKET #CodeTrackingStatement
-          | SPEED (OPEN_PARENTHESIS arg_list CLOSE_PARENTHESIS)? OPEN_CURLY_BRACKET stat CLOSE_CURLY_BRACKET #AnimationSpeedUp;
+annotation: step=(STEP_INTO | STEP_OVER) (OPEN_PARENTHESIS
+    condition=expr CLOSE_PARENTHESIS)? OPEN_CURLY_BRACKET
+    stat CLOSE_CURLY_BRACKET                                            #CodeTrackingAnnotation
+    | SPEED (OPEN_PARENTHESIS arg_list CLOSE_PARENTHESIS)?
+    OPEN_CURLY_BRACKET stat CLOSE_CURLY_BRACKET                         #AnimationSpeedUpAnnotation
+    | show=(SUBTITLE | SUBTITLE_ONCE) OPEN_PARENTHESIS
+    subtitle_text=STRING (COMMA arg_list)? CLOSE_PARENTHESIS                              #SubtitleAnnotation
+    ;
 
 forHeader: IDENT IN RANGE OPEN_PARENTHESIS (begin=expr COMMA)? end=expr (COMMA delta=expr)? CLOSE_PARENTHESIS     #RangeHeader;
 

--- a/src/main/kotlin/com/manimdsl/frontend/AbstractSyntaxTree.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/AbstractSyntaxTree.kt
@@ -34,21 +34,41 @@ data class CommentNode(override val lineNumber: Int, val content: String) : Anim
 data class CodeTrackingNode(override val lineNumber: Int, val endLineNumber: Int, val statements: List<StatementNode>) :
     NoRenderAnimationNode(lineNumber)
 
-sealed class AnnotationBlockNode(override val lineNumber: Int, open val condition: ExpressionNode) : NoRenderAnimationNode(lineNumber)
+sealed class AnnotationBlockNode(override val lineNumber: Int, open val condition: ExpressionNode) :
+    NoRenderAnimationNode(lineNumber)
 
 // Step into code and avoid additional animations
-data class StartCodeTrackingNode(override val lineNumber: Int, val isStepInto: Boolean, override val condition: ExpressionNode) :
+data class StartCodeTrackingNode(
+    override val lineNumber: Int,
+    val isStepInto: Boolean,
+    override val condition: ExpressionNode
+) :
     AnnotationBlockNode(lineNumber, condition)
 
-data class StopCodeTrackingNode(override val lineNumber: Int, val isStepInto: Boolean, override val condition: ExpressionNode) :
+data class StopCodeTrackingNode(
+    override val lineNumber: Int,
+    val isStepInto: Boolean,
+    override val condition: ExpressionNode
+) :
     AnnotationBlockNode(lineNumber, condition)
 
 // Step into code and make speed changes
-data class StartSpeedChangeNode(override val lineNumber: Int, val speedChange: ExpressionNode, override val condition: ExpressionNode) :
+data class StartSpeedChangeNode(
+    override val lineNumber: Int,
+    val speedChange: ExpressionNode,
+    override val condition: ExpressionNode
+) :
     AnnotationBlockNode(lineNumber, condition)
 
 data class StopSpeedChangeNode(override val lineNumber: Int, override val condition: ExpressionNode) :
     AnnotationBlockNode(lineNumber, condition)
+
+data class SubtitleAnnotationNode(
+    override val lineNumber: Int,
+    override val condition: ExpressionNode,
+    val text: String,
+    val showOnce: Boolean,
+) : AnnotationBlockNode(lineNumber, condition)
 
 // Code Specific Nodes holding line number
 sealed class CodeNode(override val lineNumber: Int) : StatementNode(lineNumber)

--- a/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
@@ -705,8 +705,9 @@ class ManimParserVisitor : ManimParserBaseVisitor<ASTNode>() {
 
     override fun visitInitialiser_list(ctx: Initialiser_listContext): Array2DInitialiserNode {
         return Array2DInitialiserNode(
-            (ctx.arg_list()
-                ?: listOf<ArgumentListContext>()).map { visitArgumentList(it as ArgumentListContext?).arguments }
+            (
+                ctx.arg_list() ?: listOf<ArgumentListContext>()
+                ).map { visitArgumentList(it as ArgumentListContext?).arguments }
         )
     }
 

--- a/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/ManimParserVisitor.kt
@@ -482,10 +482,7 @@ class ManimParserVisitor : ManimParserBaseVisitor<ASTNode>() {
 
     override fun visitArgumentList(ctx: ArgumentListContext?): ArgumentNode {
         return ArgumentNode(
-            (
-                    ctx?.expr()
-                        ?: listOf<ExprContext>()
-                    ).map { visit(it) as ExpressionNode }
+            (ctx?.expr() ?: listOf<ExprContext>()).map { visit(it) as ExpressionNode }
         )
     }
 
@@ -708,10 +705,8 @@ class ManimParserVisitor : ManimParserBaseVisitor<ASTNode>() {
 
     override fun visitInitialiser_list(ctx: Initialiser_listContext): Array2DInitialiserNode {
         return Array2DInitialiserNode(
-            (
-                ctx.arg_list()
-                    ?: listOf<ArgumentListContext>()
-                ).map { visitArgumentList(it as ArgumentListContext?).arguments }
+            (ctx.arg_list()
+                ?: listOf<ArgumentListContext>()).map { visitArgumentList(it as ArgumentListContext?).arguments }
         )
     }
 

--- a/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
+++ b/src/main/kotlin/com/manimdsl/frontend/SemanticAnalysis.kt
@@ -631,9 +631,9 @@ class SemanticAnalysis {
         symbolTable: SymbolTableVisitor,
         arguments: List<ExpressionNode>
     ) = when (ctx) {
-        is ManimParser.AnimationSpeedUpContext -> {
+        is ManimParser.AnimationSpeedUpAnnotationContext -> {
             if (arguments.isEmpty() || arguments.size > 2) {
-                invalidArgumentsForAnnotationError("@${ctx.SPEED().symbol.text}", ctx)
+                invalidArgumentsForAnnotationError(ctx.SPEED().symbol.text, ctx)
             } else {
                 if (arguments.size == 2) {
                     checkExpressionTypeWithExpectedType(arguments[1], BoolType, symbolTable, ctx)
@@ -641,6 +641,15 @@ class SemanticAnalysis {
                 checkExpressionTypeWithExpectedType(arguments.first(), NumberType, symbolTable, ctx)
             }
         }
-        else -> TODO()
+        is ManimParser.SubtitleAnnotationContext -> {
+            if (arguments.size > 1) {
+                invalidArgumentsForAnnotationError(ctx.show.text, ctx)
+            } else {
+                arguments.forEach {
+                    checkExpressionTypeWithExpectedType(it, BoolType, symbolTable, ctx)
+                }
+            }
+        }
+        else -> throw NotImplementedError("Annotation argument check not implemented")
     }
 }

--- a/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
@@ -25,8 +25,8 @@ class ASTConstructionTests {
     @Test
     fun multiLineProgram() {
         val multiLineProgram = "let x: number = 1.5;\n" +
-                "# code comment\n" +
-                "let y: Stack<number> = Stack<number>();\n"
+            "# code comment\n" +
+            "let y: Stack<number> = Stack<number>();\n"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 1.5)),
             DeclarationNode(
@@ -43,7 +43,7 @@ class ASTConstructionTests {
     @Test
     fun methodCallProgram() {
         val methodProgram = "let y: Stack<number> = Stack<number>();\n" +
-                "y.push(1);\n"
+            "y.push(1);\n"
         val statements = listOf(
             DeclarationNode(
                 1,
@@ -65,10 +65,10 @@ class ASTConstructionTests {
     @Test
     fun functionDeclarationProgram() {
         val functionDeclarationProgram = "fun func(x : number): number {\n" +
-                "\tlet z: number = 10;\n" +
-                "return z;\n" +
-                "}\n" +
-                "let z: number = 5;"
+            "\tlet z: number = 10;\n" +
+            "return z;\n" +
+            "}\n" +
+            "let z: number = 5;"
         val functionStatements = listOf(
             DeclarationNode(2, IdentifierNode(2, "z"), NumberNode(2, 10.0)),
             ReturnNode(3, IdentifierNode(3, "z"))
@@ -91,11 +91,11 @@ class ASTConstructionTests {
     @Test
     fun functionCallProgram() {
         val functionCallProgram = "fun func(x: number, y: number): number {\n" +
-                "\tlet z: number = x + y;\n" +
-                "return z;\n" +
-                "}\n" +
-                "let z: number = func(1,2);\n" +
-                "func(3,4);"
+            "\tlet z: number = x + y;\n" +
+            "return z;\n" +
+            "}\n" +
+            "let z: number = func(1,2);\n" +
+            "func(3,4);"
         val functionStatements = listOf(
             DeclarationNode(
                 2,
@@ -129,15 +129,15 @@ class ASTConstructionTests {
     @Test
     fun ifStatementProgram() {
         val methodProgram = "let x = 3;\n" +
-                "if(x == 2) {\n" +
-                "    x = 2;\n" +
-                "} else if (x == 1) {\n" +
-                "    x = 4;\n" +
-                "} else if (x == 0) {\n" +
-                "    x = 3;\n" +
-                "} else {\n" +
-                "    x = 1;\n" +
-                "}"
+            "if(x == 2) {\n" +
+            "    x = 2;\n" +
+            "} else if (x == 1) {\n" +
+            "    x = 4;\n" +
+            "} else if (x == 0) {\n" +
+            "    x = 3;\n" +
+            "} else {\n" +
+            "    x = 1;\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 3.0)),
             IfStatementNode(
@@ -178,11 +178,11 @@ class ASTConstructionTests {
     @Test
     fun ifStatementWithoutElifProgram() {
         val methodProgram = "let x = 3;\n" +
-                "if(x == 2) {\n" +
-                "    x = 2;\n" +
-                "} else {\n" +
-                "    x = 1;\n" +
-                "}"
+            "if(x == 2) {\n" +
+            "    x = 2;\n" +
+            "} else {\n" +
+            "    x = 1;\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 3.0)),
             IfStatementNode(
@@ -209,9 +209,9 @@ class ASTConstructionTests {
     @Test
     fun ifStatementJustIfProgram() {
         val methodProgram = "let x = 3;\n" +
-                "if(x == 2) {\n" +
-                "    x = 2;\n" +
-                "}"
+            "if(x == 2) {\n" +
+            "    x = 2;\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 3.0)),
             IfStatementNode(
@@ -232,9 +232,9 @@ class ASTConstructionTests {
     @Test
     fun whileLoopProgram() {
         val methodProgram = "let x = 0;\n" +
-                "while(x < 2) {\n" +
-                "    x = x + 1;\n" +
-                "}"
+            "while(x < 2) {\n" +
+            "    x = x + 1;\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             WhileStatementNode(
@@ -259,12 +259,12 @@ class ASTConstructionTests {
     @Test
     fun whileLoopWithBreakProgram() {
         val methodProgram = "let x = 0;\n" +
-                "while(true) {\n" +
-                "    x = x + 1;\n" +
-                "    if (x == 2) {\n" +
-                "       break;\n" +
-                "    }\n" +
-                "}"
+            "while(true) {\n" +
+            "    x = x + 1;\n" +
+            "    if (x == 2) {\n" +
+            "       break;\n" +
+            "    }\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             WhileStatementNode(
@@ -298,13 +298,13 @@ class ASTConstructionTests {
     @Test
     fun whileLoopWithContinueProgram() {
         val methodProgram = "let x = 0;\n" +
-                "while(x < 2) {\n" +
-                "    x = x + 1;\n" +
-                "    if (x == 1) {\n" +
-                "       x = 3;\n" +
-                "       continue;\n" +
-                "    }\n" +
-                "}"
+            "while(x < 2) {\n" +
+            "    x = x + 1;\n" +
+            "    if (x == 1) {\n" +
+            "       x = 3;\n" +
+            "       continue;\n" +
+            "    }\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             WhileStatementNode(
@@ -341,9 +341,9 @@ class ASTConstructionTests {
     @Test
     fun forLoopProgram() {
         val methodProgram = "let x = 0;\n" +
-                "for i in range(3) {\n" +
-                "    x = x + 1;\n" +
-                "}"
+            "for i in range(3) {\n" +
+            "    x = x + 1;\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             ForStatementNode(
@@ -374,14 +374,14 @@ class ASTConstructionTests {
     @Test
     fun nestedForLoopWithBreak() {
         val methodProgram = "let x = 0;\n" +
-                "for i in range(3) {\n" +
-                "    for j in range(i, 5) {\n" +
-                "        if (j > 2) {\n" +
-                "            break;\n" +
-                "        }\n" +
-                "        x = i * j;\n" +
-                "    }\n" +
-                "}"
+            "for i in range(3) {\n" +
+            "    for j in range(i, 5) {\n" +
+            "        if (j > 2) {\n" +
+            "            break;\n" +
+            "        }\n" +
+            "        x = i * j;\n" +
+            "    }\n" +
+            "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             ForStatementNode(

--- a/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
+++ b/src/test/kotlin/com/manimdsl/ASTConstructionTests.kt
@@ -25,8 +25,8 @@ class ASTConstructionTests {
     @Test
     fun multiLineProgram() {
         val multiLineProgram = "let x: number = 1.5;\n" +
-            "# code comment\n" +
-            "let y: Stack<number> = Stack<number>();\n"
+                "# code comment\n" +
+                "let y: Stack<number> = Stack<number>();\n"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 1.5)),
             DeclarationNode(
@@ -43,7 +43,7 @@ class ASTConstructionTests {
     @Test
     fun methodCallProgram() {
         val methodProgram = "let y: Stack<number> = Stack<number>();\n" +
-            "y.push(1);\n"
+                "y.push(1);\n"
         val statements = listOf(
             DeclarationNode(
                 1,
@@ -65,10 +65,10 @@ class ASTConstructionTests {
     @Test
     fun functionDeclarationProgram() {
         val functionDeclarationProgram = "fun func(x : number): number {\n" +
-            "\tlet z: number = 10;\n" +
-            "return z;\n" +
-            "}\n" +
-            "let z: number = 5;"
+                "\tlet z: number = 10;\n" +
+                "return z;\n" +
+                "}\n" +
+                "let z: number = 5;"
         val functionStatements = listOf(
             DeclarationNode(2, IdentifierNode(2, "z"), NumberNode(2, 10.0)),
             ReturnNode(3, IdentifierNode(3, "z"))
@@ -91,11 +91,11 @@ class ASTConstructionTests {
     @Test
     fun functionCallProgram() {
         val functionCallProgram = "fun func(x: number, y: number): number {\n" +
-            "\tlet z: number = x + y;\n" +
-            "return z;\n" +
-            "}\n" +
-            "let z: number = func(1,2);\n" +
-            "func(3,4);"
+                "\tlet z: number = x + y;\n" +
+                "return z;\n" +
+                "}\n" +
+                "let z: number = func(1,2);\n" +
+                "func(3,4);"
         val functionStatements = listOf(
             DeclarationNode(
                 2,
@@ -129,15 +129,15 @@ class ASTConstructionTests {
     @Test
     fun ifStatementProgram() {
         val methodProgram = "let x = 3;\n" +
-            "if(x == 2) {\n" +
-            "    x = 2;\n" +
-            "} else if (x == 1) {\n" +
-            "    x = 4;\n" +
-            "} else if (x == 0) {\n" +
-            "    x = 3;\n" +
-            "} else {\n" +
-            "    x = 1;\n" +
-            "}"
+                "if(x == 2) {\n" +
+                "    x = 2;\n" +
+                "} else if (x == 1) {\n" +
+                "    x = 4;\n" +
+                "} else if (x == 0) {\n" +
+                "    x = 3;\n" +
+                "} else {\n" +
+                "    x = 1;\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 3.0)),
             IfStatementNode(
@@ -178,11 +178,11 @@ class ASTConstructionTests {
     @Test
     fun ifStatementWithoutElifProgram() {
         val methodProgram = "let x = 3;\n" +
-            "if(x == 2) {\n" +
-            "    x = 2;\n" +
-            "} else {\n" +
-            "    x = 1;\n" +
-            "}"
+                "if(x == 2) {\n" +
+                "    x = 2;\n" +
+                "} else {\n" +
+                "    x = 1;\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 3.0)),
             IfStatementNode(
@@ -209,9 +209,9 @@ class ASTConstructionTests {
     @Test
     fun ifStatementJustIfProgram() {
         val methodProgram = "let x = 3;\n" +
-            "if(x == 2) {\n" +
-            "    x = 2;\n" +
-            "}"
+                "if(x == 2) {\n" +
+                "    x = 2;\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 3.0)),
             IfStatementNode(
@@ -232,9 +232,9 @@ class ASTConstructionTests {
     @Test
     fun whileLoopProgram() {
         val methodProgram = "let x = 0;\n" +
-            "while(x < 2) {\n" +
-            "    x = x + 1;\n" +
-            "}"
+                "while(x < 2) {\n" +
+                "    x = x + 1;\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             WhileStatementNode(
@@ -259,12 +259,12 @@ class ASTConstructionTests {
     @Test
     fun whileLoopWithBreakProgram() {
         val methodProgram = "let x = 0;\n" +
-            "while(true) {\n" +
-            "    x = x + 1;\n" +
-            "    if (x == 2) {\n" +
-            "       break;\n" +
-            "    }\n" +
-            "}"
+                "while(true) {\n" +
+                "    x = x + 1;\n" +
+                "    if (x == 2) {\n" +
+                "       break;\n" +
+                "    }\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             WhileStatementNode(
@@ -298,13 +298,13 @@ class ASTConstructionTests {
     @Test
     fun whileLoopWithContinueProgram() {
         val methodProgram = "let x = 0;\n" +
-            "while(x < 2) {\n" +
-            "    x = x + 1;\n" +
-            "    if (x == 1) {\n" +
-            "       x = 3;\n" +
-            "       continue;\n" +
-            "    }\n" +
-            "}"
+                "while(x < 2) {\n" +
+                "    x = x + 1;\n" +
+                "    if (x == 1) {\n" +
+                "       x = 3;\n" +
+                "       continue;\n" +
+                "    }\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             WhileStatementNode(
@@ -323,7 +323,10 @@ class ASTConstructionTests {
                         endLineNumber = 7,
                         scope = 2,
                         condition = EqExpression(4, IdentifierNode(4, "x"), NumberNode(4, 1.0)),
-                        statements = listOf(AssignmentNode(5, IdentifierNode(5, "x"), NumberNode(5, 3.0)), ContinueNode(6, 2)),
+                        statements = listOf(
+                            AssignmentNode(5, IdentifierNode(5, "x"), NumberNode(5, 3.0)),
+                            ContinueNode(6, 2)
+                        ),
                         elifs = emptyList(),
                         elseBlock = ElseNode(7, 0, emptyList())
                     )
@@ -338,9 +341,9 @@ class ASTConstructionTests {
     @Test
     fun forLoopProgram() {
         val methodProgram = "let x = 0;\n" +
-            "for i in range(3) {\n" +
-            "    x = x + 1;\n" +
-            "}"
+                "for i in range(3) {\n" +
+                "    x = x + 1;\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             ForStatementNode(
@@ -349,7 +352,11 @@ class ASTConstructionTests {
                 scope = 1,
                 beginStatement = DeclarationNode(2, IdentifierNode(2, "i"), NumberNode(2, 0.0)),
                 endCondition = NumberNode(2, 3.0),
-                updateCounter = AssignmentNode(2, IdentifierNode(2, "i"), AddExpression(2, IdentifierNode(3, "i"), NumberNode(2, 1.0))),
+                updateCounter = AssignmentNode(
+                    2,
+                    IdentifierNode(2, "i"),
+                    AddExpression(2, IdentifierNode(3, "i"), NumberNode(2, 1.0))
+                ),
                 statements = listOf(
                     AssignmentNode(
                         3,
@@ -367,14 +374,14 @@ class ASTConstructionTests {
     @Test
     fun nestedForLoopWithBreak() {
         val methodProgram = "let x = 0;\n" +
-            "for i in range(3) {\n" +
-            "    for j in range(i, 5) {\n" +
-            "        if (j > 2) {\n" +
-            "            break;\n" +
-            "        }\n" +
-            "        x = i * j;\n" +
-            "    }\n" +
-            "}"
+                "for i in range(3) {\n" +
+                "    for j in range(i, 5) {\n" +
+                "        if (j > 2) {\n" +
+                "            break;\n" +
+                "        }\n" +
+                "        x = i * j;\n" +
+                "    }\n" +
+                "}"
         val statements = listOf(
             DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 0.0)),
             ForStatementNode(
@@ -383,7 +390,11 @@ class ASTConstructionTests {
                 scope = 1,
                 beginStatement = DeclarationNode(2, IdentifierNode(2, "i"), NumberNode(2, 0.0)),
                 endCondition = NumberNode(2, 3.0),
-                updateCounter = AssignmentNode(2, IdentifierNode(2, "i"), AddExpression(2, IdentifierNode(3, "i"), NumberNode(2, 1.0))),
+                updateCounter = AssignmentNode(
+                    2,
+                    IdentifierNode(2, "i"),
+                    AddExpression(2, IdentifierNode(3, "i"), NumberNode(2, 1.0))
+                ),
                 statements = listOf(
                     ForStatementNode(
                         lineNumber = 3,
@@ -391,7 +402,11 @@ class ASTConstructionTests {
                         scope = 2,
                         beginStatement = DeclarationNode(3, IdentifierNode(3, "j"), IdentifierNode(3, "i")),
                         endCondition = NumberNode(3, 5.0),
-                        updateCounter = AssignmentNode(3, IdentifierNode(3, "j"), AddExpression(3, IdentifierNode(3, "j"), NumberNode(3, 1.0))),
+                        updateCounter = AssignmentNode(
+                            3,
+                            IdentifierNode(3, "j"),
+                            AddExpression(3, IdentifierNode(3, "j"), NumberNode(3, 1.0))
+                        ),
                         statements = listOf(
                             IfStatementNode(
                                 lineNumber = 4,
@@ -412,6 +427,49 @@ class ASTConstructionTests {
                 )
             )
         )
+        val reference = ProgramNode(listOf(), statements)
+        val actual = buildAST(methodProgram)
+        assertEquals(reference.toString(), actual.toString())
+    }
+
+    @Test
+    fun subtitleAnnotations() {
+        val methodProgram = """
+            let x = 4;
+            @subtitle("x is 4", x == 4)
+            @subtitleOnce("x is not 4", x != 4)
+            @subtitleOnce("x is not 4")
+            @subtitle("x is 4")
+        """.trimIndent()
+
+        val statements = listOf<StatementNode>(
+            DeclarationNode(1, IdentifierNode(1, "x"), NumberNode(1, 4.0)),
+            SubtitleAnnotationNode(
+                2,
+                condition = EqExpression(2, IdentifierNode(2, "x"), NumberNode(2, 4.0)),
+                "x is 4",
+                showOnce = false
+            ),
+            SubtitleAnnotationNode(
+                3,
+                condition = NeqExpression(3, IdentifierNode(3, "x"), NumberNode(3, 4.0)),
+                "x is not 4",
+                showOnce = true
+            ),
+            SubtitleAnnotationNode(
+                4,
+                condition = BoolNode(4, true),
+                "x is not 4",
+                showOnce = true
+            ),
+            SubtitleAnnotationNode(
+                5,
+                condition = BoolNode(5, true),
+                "x is 4",
+                showOnce = false
+            )
+        )
+
         val reference = ProgramNode(listOf(), statements)
         val actual = buildAST(methodProgram)
         assertEquals(reference.toString(), actual.toString())


### PR DESCRIPTION
### Clubhouse Ticket
[ch314](https://app.clubhouse.io/manim-dsl/story/314/implement-subtitle-decorator-on-frontend)

### Description

Implemented subtitle annotation on frontend. User can now use subtitles as follows:
`@subtitle("subtitle")` - A standard subtitle that will show whenever it is executed
`@subtitleOnce("subtitle")` - A subtitle that will show only once  and will not be shown after first execution
`@subtitleOnce("subtitle", x < 3)` - A subtitle that will show only once when condition is true
`@subtitle("subtitle", x < 3)` - A subtitle that will show when condition is true
### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Added AST construction test

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules