### PR TITLE
Fix subtitle early wrapping

### DIFF
--- a/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
+++ b/src/main/kotlin/com/manimdsl/linearrepresentation/LinearRepresentation.kt
@@ -66,7 +66,7 @@ data class UpdateSubtitle(
     override fun toPython(): List<String> {
         val instr = mutableListOf("self.play_animation(${subtitleBlock.ident}.clear())")
         if (!text.isBlank()) {
-            instr.add("self.play_animation(${subtitleBlock.ident}.display($text, self.get_time() + ${subtitleBlock.duration}))")
+            instr.add("self.play_animation(${subtitleBlock.ident}.display('$text', self.get_time() + ${subtitleBlock.duration}))")
         }
 
         return instr

--- a/src/main/kotlin/com/manimdsl/runtime/VirtualMachine.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/VirtualMachine.kt
@@ -468,7 +468,7 @@ class VirtualMachine(
             linearRepresentation.add(
                 UpdateSubtitle(
                     (subtitleBlockVariable as SubtitleBlock),
-                    wrapString(text, 30),
+                    wrapString(text, 65),
                     runtime = animationSpeeds.first()
                 )
             )

--- a/src/main/kotlin/com/manimdsl/runtime/VirtualMachine.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/VirtualMachine.kt
@@ -441,7 +441,7 @@ class VirtualMachine(
                     }
 
                     val text = executeExpression(statement.text) as StringValue
-                    updateSubtitle(text.toString(), duration)
+                    updateSubtitle(text.value, duration)
                     EmptyValue
                 } else {
                     EmptyValue

--- a/src/main/resources/python/subtitles.py
+++ b/src/main/resources/python/subtitles.py
@@ -15,6 +15,8 @@ class Subtitle_block:
         self.text = Text(text, color=self.text_color, weight=self.text_weight, font=self.font)
         if self.text.get_height() > self.height:
             self.text.scale(self.height / self.text.get_height())
+        if self.text.get_width() > self.width:
+            self.text.scale(self.width / self.text.get_width())
 
     def display(self, text, end_time):
         self.change_text(text)


### PR DESCRIPTION
### Clubhouse Ticket
[ch382](https://app.clubhouse.io/manim-dsl/story/382/subtitle-wraps-line-to-early)

### Description

Line wrapping occurring too early so string not using full width. Increased length of line wrap

Fixes # (issue) 

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue) :bug

### How Has This Been Tested?

Please describe tests added as well.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules