### PR TITLE
Wrap on comma for long 2d array initialisation

### DIFF
--- a/src/main/kotlin/com/manimdsl/runtime/utility/UtilityFunctions.kt
+++ b/src/main/kotlin/com/manimdsl/runtime/utility/UtilityFunctions.kt
@@ -41,7 +41,7 @@ fun wrapCode(code: MutableList<String>): MutableList<MutableList<String>> {
  */
 
 fun wrapLine(line: String): Int {
-    val list = line.split(" ")
+    val list = line.split(" ", ",")
     var counter = 0
     var prevCounter = 0
     for (word in list) {


### PR DESCRIPTION
### Description

Wrap code line on comma for long 2D Array initialisation to avoid infinite loop when compiling/

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue) :bug

### How Has This Been Tested?

Existing test

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules